### PR TITLE
Adding gitignore for generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+CMakeCache.txt
+DartConfiguration.tcl
+Makefile
+*.cmake
+CMakeFiles/
+Testing/
+include/
+lib/
+test/


### PR DESCRIPTION
When using this project as a git submodule, the generated files show up as constant 'untracked content'. Adding this .gitignore solves the problem.
