### PR TITLE
Exporting binary tree to CMake registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,7 @@ endif ()
 # support direct use of build tree
 set (INSTALL_PREFIX_REL2CONFIG_DIR .)
 export (TARGETS gflags gflags_nothreads FILE "${PROJECT_BINARY_DIR}/${PACKAGE_NAME}-export.cmake")
+export (PACKAGE gflags)
 configure_file (cmake/config.cmake.in "${PROJECT_BINARY_DIR}/${PACKAGE_NAME}-config.cmake" @ONLY)
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
This eases integration with other applications making use of gflags without needing to install it in the system. find_package looks in this registry for existing software.
