### PR TITLE
Linux compatibility fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set (PACKAGE_STRING    "${PROJECT_NAME} ${PACKAGE_VERSION}")
 set (PACKAGE_TARNAME   "${PROJECT_NAME}-${PACKAGE_VERSION}")
 set (PACKAGE_BUGREPORT "https://code.google.com/p/gflags/issues/")
 
-project (${PROJECT_NAME} CXX)
+project (${PROJECT_NAME} CXX C)
 
 version_numbers (
   ${PACKAGE_VERSION}
@@ -62,7 +62,7 @@ endif ()
 # system checks
 include (CheckTypeSize)
 include (CheckIncludeFileCXX)
-include (CheckCxxSymbolExists)
+include (CheckCXXSymbolExists)
 
 set (GFLAGS_INTTYPES_FORMAT "" CACHE STRING "Format of integer types: \"C99\" (uint32_t), \"BSD\" (u_int32_t), \"VC7\" (__int32)")
 mark_as_advanced(GFLAGS_INTTYPES_FORMAT)

--- a/cmake/FindThreadsCxx.cmake
+++ b/cmake/FindThreadsCxx.cmake
@@ -35,7 +35,7 @@
 
 include (CheckIncludeFileCXX)
 include (CheckLibraryExists)
-include (CheckCxxSymbolExists)
+include (CheckCXXSymbolExists)
 set(Threads_FOUND FALSE)
 
 # Do we have sproc?


### PR DESCRIPTION
- fixed letter case of included file names
- C language definition is needed for CheckForPthreads.c

Hi,
I am working with your cmake-migration build and found a problem today.
I fixed it real quick and tested it on Ubuntu but it should also work on any other system.
Best regards
Andreas
