### PR TITLE
Added nuget support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,9 @@ foreach (TYPE IN ITEMS STATIC SHARED)
                                            VERSION             "${PACKAGE_VERSION}"
                                            SOVERSION           "${PACKAGE_SOVERSION}"
         )
+        if (MSVC)
+           set_target_properties (gflags${opts}-${type} PROPERTIES DEBUG_POSTFIX "d")
+        endif() 
         if (HAVE_SHLWAPI_H)
           target_link_libraries (gflags${opts}-${type} shlwapi.lib)
         endif ()

--- a/nuget/BuildAndWriteNugetPackage.ps1
+++ b/nuget/BuildAndWriteNugetPackage.ps1
@@ -1,0 +1,100 @@
+function BuildPivot( $source_dir, $build_dir, $generator, $options ) {
+    if(!(Test-Path -Path $build_dir )){
+        mkdir $build_dir
+    }
+
+    pushd $build_dir 
+    cmake -G $generator $options -DCMAKE_INSTALL_PREFIX=install $source_dir
+    cmake --build . --target INSTALL --config Debug
+    cmake --build . --target INSTALL --config Release
+    popd
+}
+
+$source_dir   = "$PSScriptRoot\.."
+
+# VS 2013
+#######################################################
+$build_dir = "./build/x64/v120/static"
+$generator = "Visual Studio 12 Win64"
+$options ="-DBUILD_SHARED_LIBS=OFF"
+
+BuildPivot $source_dir $build_dir $generator $options
+
+$build_dir = "./build/x64/v120/dynamic"
+$generator = "Visual Studio 12 Win64"
+$options ="-DBUILD_SHARED_LIBS=ON"
+
+BuildPivot $source_dir $build_dir $generator $options
+
+$build_dir = "./build/Win32/v120/static"
+$generator = "Visual Studio 12"
+$options ="-DBUILD_SHARED_LIBS=OFF"
+
+BuildPivot $source_dir $build_dir $generator $options
+
+$build_dir = "./build/Win32/v120/dynamic"
+$generator = "Visual Studio 12"
+$options ="-DBUILD_SHARED_LIBS=ON"
+
+BuildPivot $source_dir $build_dir $generator $options
+
+#######################################################
+
+# VS 2012
+#######################################################
+$build_dir = "./build/x64/v110/static"
+$generator = "Visual Studio 11 Win64"
+$options ="-DBUILD_SHARED_LIBS=OFF"
+
+BuildPivot $source_dir $build_dir $generator $options
+
+$build_dir = "./build/x64/v110/dynamic"
+$generator = "Visual Studio 11 Win64"
+$options ="-DBUILD_SHARED_LIBS=ON"
+
+BuildPivot $source_dir $build_dir $generator $options
+
+$build_dir = "./build/Win32/v110/static"
+$generator = "Visual Studio 11"
+$options ="-DBUILD_SHARED_LIBS=OFF"
+
+BuildPivot $source_dir $build_dir $generator $options
+
+$build_dir = "./build/Win32/v110/dynamic"
+$generator = "Visual Studio 11"
+$options ="-DBUILD_SHARED_LIBS=ON"
+
+BuildPivot $source_dir $build_dir $generator $options
+#######################################################
+
+# VS 2010
+#######################################################
+$build_dir = "./build/x64/v100/static"
+$generator = "Visual Studio 10 Win64"
+$options ="-DBUILD_SHARED_LIBS=OFF"
+
+BuildPivot $source_dir $build_dir $generator $options
+
+$build_dir = "./build/x64/v100/dynamic"
+$generator = "Visual Studio 10 Win64"
+$options ="-DBUILD_SHARED_LIBS=ON"
+
+BuildPivot $source_dir $build_dir $generator $options
+
+$build_dir = "./build/Win32/v100/static"
+$generator = "Visual Studio 10"
+$options ="-DBUILD_SHARED_LIBS=OFF"
+
+BuildPivot $source_dir $build_dir $generator $options
+
+$build_dir = "./build/Win32/v100/dynamic"
+$generator = "Visual Studio 10"
+$options ="-DBUILD_SHARED_LIBS=ON"
+
+BuildPivot $source_dir $build_dir $generator $options
+#######################################################
+
+Write-NuGetPackage  -SplitThreshold 10000000 .\gflags.autopkg
+
+
+

--- a/nuget/README.md
+++ b/nuget/README.md
@@ -9,25 +9,27 @@ To create a nuget package for the gflags library:
 This will create a nuget package for gflags that can be used from VS or CMake. CMake usage example:
 
 In PS execute:
-
-    PS> nuget install gflags -ExcludeVersion
+```PowerShell
+PS> nuget install gflags -ExcludeVersion
+```
     
 Then in your CMakeLists.txt:
+```CMake
+cmake_minimum_required(VERSION 2.8.12)
 
-    cmake_minimum_required(VERSION 2.8.12)
+project(test_gflags)
 
-    project(test_gflags)
+# make sure CMake finds the nuget installed package
+find_package(gflags REQUIRED)
 
-    # make sure CMake finds the nuget installed package
-    find_package(gflags REQUIRED)
+add_executable(test_gflags main.cpp)
 
-    add_executable(test_gflags main.cpp)
+# gflags libraries are automatically mapped to the good arch/VS version/linkage combination
+target_link_libraries(test_gflags ${gflags_LIBRARIES})
+target_include_directories(test_gflags PRIVATE ${gflags_INCLUDE_DIR})
 
-    # gflags libraries are automatically mapped to the good arch/VS version/linkage combination
-    target_link_libraries(test_gflags ${gflags_LIBRARIES})
-    target_include_directories(test_gflags PRIVATE ${gflags_INCLUDE_DIR})
-
-    # copy the DLL to the output folder if desired.
-    if (MSVC AND COMMAND target_copy_shared_libs AND NOT gflags_STATIC)
-      target_copy_shared_libs(test_gflags ${gflags_LIBRARIES})
-    endif ()
+# copy the DLL to the output folder if desired.
+if (MSVC AND COMMAND target_copy_shared_libs AND NOT gflags_STATIC)
+  target_copy_shared_libs(test_gflags ${gflags_LIBRARIES})
+endif ()
+```    

--- a/nuget/README.md
+++ b/nuget/README.md
@@ -1,0 +1,33 @@
+## Packaging gflags for Nuget
+
+To create a nuget package for the gflags library: 
+
+* Install the CoApp tools: http://downloads.coapp.org/files/Development.CoApp.Tools.Powershell.msi 
+* Install VS 2010, 2012 and 2013.
+* Run the BuildAndWriteNugetPackage.ps1 PS script from this folder.
+
+This will create a nuget package for gflags that can be used from VS or CMake. CMake usage example:
+
+In PS execute:
+
+    PS> nuget install gflags -ExcludeVersion
+    
+Then in your CMakeLists.txt:
+
+    cmake_minimum_required(VERSION 2.8.12)
+
+    project(test_gflags)
+
+    # make sure CMake finds the nuget installed package
+    find_package(gflags REQUIRED)
+
+    add_executable(test_gflags main.cpp)
+
+    # gflags libraries are automatically mapped to the good arch/VS version/linkage combination
+    target_link_libraries(test_gflags ${gflags_LIBRARIES})
+    target_include_directories(test_gflags PRIVATE ${gflags_INCLUDE_DIR})
+
+    # copy the DLL to the output folder if desired.
+    if (MSVC AND COMMAND target_copy_shared_libs AND NOT gflags_STATIC)
+      target_copy_shared_libs(test_gflags ${gflags_LIBRARIES})
+    endif ()

--- a/nuget/TargetCopySharedLibs.cmake
+++ b/nuget/TargetCopySharedLibs.cmake
@@ -1,0 +1,49 @@
+# - Copy shared library dependencies to output folder of target for Debug and Release configurations
+#
+# This can be used to emulate Nuget packages behaviour on Windows.
+# WARNING: This macro was only tested on Windows and contains Windows specific code. It is a no-op if MSVC is not the actual compiler.
+# TODO: Support all configurations
+# Guillaume Dumont, 2014
+
+macro(target_copy_shared_libs target )      
+  if(MSVC)
+    get_target_property (TARGET_LOCATION_DEBUG   ${target} LOCATION_Debug)
+    get_target_property (TARGET_LOCATION_RELEASE ${target} LOCATION_Release)      
+    if(TARGET_LOCATION_DEBUG AND TARGET_LOCATION_RELEASE)
+      get_filename_component (TARGET_LOCATION_DEBUG "${TARGET_LOCATION_DEBUG}" PATH)
+      get_filename_component (TARGET_LOCATION_RELEASE "${TARGET_LOCATION_RELEASE}" PATH)    
+      
+      foreach (_shared_lib ${ARGN})
+          
+        get_target_property( SHARED_LIB_LOCATION_DEBUG   ${_shared_lib} LOCATION_Debug)
+        get_target_property( SHARED_LIB_LOCATION_RELEASE ${_shared_lib} LOCATION_Release)
+        
+        if (SHARED_LIB_LOCATION_DEBUG)
+          get_filename_component(SHARED_LIB_EXT ${SHARED_LIB_LOCATION_DEBUG} EXT)
+          if (SHARED_LIB_EXT MATCHES ".dll")
+            set(IS_SHARED_LIB_DEBUG ON)
+          endif ()
+        endif ()
+        
+        if (SHARED_LIB_LOCATION_RELEASE)
+          get_filename_component(SHARED_LIB_EXT ${SHARED_LIB_LOCATION_RELEASE} EXT)
+          if (SHARED_LIB_EXT MATCHES ".dll")
+            set(IS_SHARED_LIB_RELEASE ON)
+          endif ()
+        endif ()
+        
+        if (IS_SHARED_LIB_DEBUG AND IS_SHARED_LIB_RELEASE)
+          
+          add_custom_command( TARGET ${target} POST_BUILD
+                              COMMAND ${CMAKE_COMMAND} -E copy_if_different $<$<CONFIG:Debug>:${SHARED_LIB_LOCATION_DEBUG}> $<$<CONFIG:Debug>:${TARGET_LOCATION_DEBUG}>
+                                                                            $<$<NOT:$<CONFIG:Debug>>:${SHARED_LIB_LOCATION_RELEASE}> $<$<NOT:$<CONFIG:Debug>>:${TARGET_LOCATION_RELEASE}> 
+                              )  
+        else ()
+          message( WARNING "Target {_shared_lib} could not be found or is not a DLL.")
+        endif ()
+      endforeach ()
+    else ()
+      message( WARNING "Could not find Debug and/or Release configurations for target: ${target}")
+    endif ()
+    endif()
+endmacro()

--- a/nuget/gflags-config.cmake
+++ b/nuget/gflags-config.cmake
@@ -1,0 +1,67 @@
+# - Nuget specific gflags-config cmake file
+#
+# This wrap the inclusion of the true gflags-config.cmake 
+# so that the nuget package can be used from cmake as well.
+# This files takes care of mapping the gflags-config to the proper
+# architecture/compiler/linkage version of the library.
+# Guillaume Dumont, 2014
+
+if(NOT DEFINED gflags_STATIC)
+  # look for global setting
+  if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
+    option (gflags_STATIC "Link to static gflags name" OFF)
+  else()
+    option (gflags_STATIC "Link to static gflags name" ON)
+  endif()
+endif()
+
+# Determine if we link to static or shared libraries
+if (gflags_STATIC)
+  set (MSVC_LINKAGE static)
+else()
+  set (MSVC_LINKAGE dynamic)
+endif()
+
+# Determine architecture
+if (CMAKE_CL_64)
+  set (MSVC_ARCH x64)
+else ()
+  set (MSVC_ARCH Win32)
+endif ()
+
+# Determine VS version
+set (MSVC_VERSIONS 1600 1700 1800)
+set (MSVC_TOOLSETS v100 v110 v120)
+
+list (LENGTH MSVC_VERSIONS N_VERSIONS)
+math (EXPR N_LOOP "${N_VERSIONS} - 1")
+
+foreach (i RANGE ${N_LOOP})        
+  list (GET MSVC_VERSIONS ${i} _msvc_version)
+  if (_msvc_version EQUAL MSVC_VERSION)
+    list (GET MSVC_TOOLSETS ${i} MSVC_TOOLSET)
+  endif ()    
+endforeach () 
+if (NOT MSVC_TOOLSET)
+  message( WARNING "Could not find binaries matching your compiler version. Defaulting to v120." )
+  set( MSVC_TOOLSET v120 )
+endif ()
+
+get_filename_component (CMAKE_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+# Include CMake generated configuration file for proper config
+include ("${CMAKE_CURRENT_LIST_DIR}/build/native/${MSVC_ARCH}/${MSVC_TOOLSET}/${MSVC_LINKAGE}/CMake/gflags-config.cmake")
+
+# overwrite include directory. CMake points to a directory which is not existent in the nuget package
+set (gflags_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/build/native/include")
+
+# Redefine this as well since target names do not match
+# actual binaries.
+if (gflags_STATIC)
+  set (gflags_LIBRARIES gflags-static)
+else ()
+  set (gflags_LIBRARIES gflags-shared)  
+endif()
+
+# include a macro that makes it easy to copy gflags DLLs to output folder.
+include("${CMAKE_CURRENT_LIST_DIR}/TargetCopySharedLibs.cmake")

--- a/nuget/gflags.autopkg
+++ b/nuget/gflags.autopkg
@@ -1,9 +1,26 @@
+configurations {
+    // define the threads option so that one can link on gflags or gflags_nothreads
+    Threads {         
+        description = "Link with gflags.lib or gflags_nothreads.lib";
+        choices: { threads, nothreads }; 
+        
+        
+        threads { 
+            description = "With Threads";
+        };
+        
+        nothreads { 
+            description = "Without Threads";
+        };
+    };
+};
+
 nuget
 {
     nuspec
     {
         id = gflags;
-        version : 2.1.1.0-alpha;
+        version : 2.1.1.2-beta;
         title: gflags;
         authors: { Guillaume Dumont };      
         licenseUrl: "http://opensource.org/licenses/BSD-3-Clause";
@@ -48,31 +65,60 @@ nuget
                                     ".\build\${0}\${1}\${2}\install\CMake\*.cmake";
                                 };
                         };
-                        [${0},${1},${2},Debug] {  
+                        [${0},${1},${2},Debug,threads] {  
                                 lib: {                                 
                                     #destination = ${build_root}\${0}\${1}\${2}\Lib;
-                                    ".\build\${0}\${1}\${2}\install\Lib\*d.lib";
+                                    ".\build\${0}\${1}\${2}\install\Lib\gflagsd.lib";
                                 };           
                                 bin: {                                 
                                     #destination = ${build_root}\${0}\${1}\${2}\Lib;
-                                    ".\build\${0}\${1}\${2}\install\Lib\*d.dll";
+                                    ".\build\${0}\${1}\${2}\install\Lib\gflagsd.dll";
                                 };
                         };
-                        [${0},${1},${2},Release] {  
+                        [${0},${1},${2},Release,threads] {  
                                 lib: {                                 
                                     #destination = ${build_root}\${0}\${1}\${2}\Lib;
-                                    ".\build\${0}\${1}\${2}\install\Lib\*s.lib";
+                                    ".\build\${0}\${1}\${2}\install\Lib\gflags.lib";
                                 };           
                                 bin: {                                 
                                     #destination = ${build_root}\${0}\${1}\${2}\Lib;
-                                    ".\build\${0}\${1}\${2}\install\Lib\*s.dll";
+                                    ".\build\${0}\${1}\${2}\install\Lib\gflags.dll";
+                                };
+                        };
+                         [${0},${1},${2},Debug,nothreads] {  
+                                lib: {                                 
+                                    #destination = ${build_root}\${0}\${1}\${2}\Lib;
+                                    ".\build\${0}\${1}\${2}\install\Lib\gflags_nothreadsd.lib";
+                                };           
+                                bin: {                                 
+                                    #destination = ${build_root}\${0}\${1}\${2}\Lib;
+                                    ".\build\${0}\${1}\${2}\install\Lib\gflags_nothreadsd.dll";
+                                };
+                        };
+                        [${0},${1},${2},Release,nothreads] {  
+                                lib: {                                 
+                                    #destination = ${build_root}\${0}\${1}\${2}\Lib;
+                                    ".\build\${0}\${1}\${2}\install\Lib\gflags_nothreads.lib";
+                                };           
+                                bin: {                                 
+                                    #destination = ${build_root}\${0}\${1}\${2}\Lib;
+                                    ".\build\${0}\${1}\${2}\install\Lib\gflags_nothreads.dll";
                                 };
                         };
                         
                 };                        
     };
     
+    props {
+        // default to threads (rather than no threads)
+        Threads = threads;
+    };
+    
     targets {
+        // Hard code the need for shlwapi.lib. We should probably get this from CMake export files. 
+        [static] {
+            Libraries += "shlwapi.lib";
+        };
         Includes += ${pkg_root}/${d_include}; 
     };
 }

--- a/nuget/gflags.autopkg
+++ b/nuget/gflags.autopkg
@@ -3,7 +3,7 @@ nuget
     nuspec
     {
         id = gflags;
-        version : 2.1.1.0;
+        version : 2.1.1.0-alpha;
         title: gflags;
         authors: { Guillaume Dumont };      
         licenseUrl: "http://opensource.org/licenses/BSD-3-Clause";

--- a/nuget/gflags.autopkg
+++ b/nuget/gflags.autopkg
@@ -20,7 +20,7 @@ nuget
     nuspec
     {
         id = gflags;
-        version : 2.1.1.2-beta;
+        version : 2.1.1.2;
         title: gflags;
         authors: { Guillaume Dumont };      
         licenseUrl: "http://opensource.org/licenses/BSD-3-Clause";

--- a/nuget/gflags.autopkg
+++ b/nuget/gflags.autopkg
@@ -1,0 +1,78 @@
+nuget
+{
+    nuspec
+    {
+        id = gflags;
+        version : 2.1.1.0;
+        title: gflags;
+        authors: { Guillaume Dumont };      
+        licenseUrl: "http://opensource.org/licenses/BSD-3-Clause";
+        projectUrl: "https://code.google.com/p/gflags/";     
+        iconUrl: "https://ssl.gstatic.com/codesite/ph/images/defaultlogo.png"        
+        requireLicenseAcceptance:false;
+        summary:Commandline flags module for C++;
+
+        /* if you need to span several lines you can prefix a string with 
+         an @ symbol (exactly like c# does). */
+         
+         description: @"The gflags package contains a library that implements commandline flags processing. 
+         As such it's a replacement for getopt(). It has increased flexibility, including built-in support 
+         for C++ types like string, and the ability to define flags in the source file in which they're used.
+         
+         This nuget package includes static and shared binaries for 32 and 64 bit architectures 
+         and for v100, v110 and v120 platform toolsets.";
+               
+        releaseNotes: "Updated to new gflags version and added support for CMake.";
+        copyright: Copyright 2013;
+        tags: { native, CoApp, gflags, commandline };
+    };
+    
+    files
+    {           
+        nestedInclude: {
+            #destination = ${d_include}\gflags;
+            ".\build\x64\v120\static\install\Include\gflags\*"
+        };        
+        
+        config: {
+            #destination = ${pkg_root};
+            ".\build\x64\v120\static\install\CMake\gflags-config-version.cmake";
+            ".\*.cmake";                                    
+        };
+        
+                
+        ("x64,Win32", "v100,v110,v120", "static,dynamic") => {
+                        [${0},${1},${2}] {                                         
+                                cmake: {
+                                    #destination = ${build_root}\${0}\${1}\${2}\CMake;
+                                    ".\build\${0}\${1}\${2}\install\CMake\*.cmake";
+                                };
+                        };
+                        [${0},${1},${2},Debug] {  
+                                lib: {                                 
+                                    #destination = ${build_root}\${0}\${1}\${2}\Lib;
+                                    ".\build\${0}\${1}\${2}\install\Lib\*d.lib";
+                                };           
+                                bin: {                                 
+                                    #destination = ${build_root}\${0}\${1}\${2}\Lib;
+                                    ".\build\${0}\${1}\${2}\install\Lib\*d.dll";
+                                };
+                        };
+                        [${0},${1},${2},Release] {  
+                                lib: {                                 
+                                    #destination = ${build_root}\${0}\${1}\${2}\Lib;
+                                    ".\build\${0}\${1}\${2}\install\Lib\*s.lib";
+                                };           
+                                bin: {                                 
+                                    #destination = ${build_root}\${0}\${1}\${2}\Lib;
+                                    ".\build\${0}\${1}\${2}\install\Lib\*s.dll";
+                                };
+                        };
+                        
+                };                        
+    };
+    
+    targets {
+        Includes += ${pkg_root}/${d_include}; 
+    };
+}


### PR DESCRIPTION
Here is my second attempt at including nuget support for gflags. 

It now uses the CMake build system as you mentioned in the previous PR. 

I tried to be less instrusive as possible in the gflags build but I had to modify your CMakeLists in a little so that we can install both Release and Debug libs alongside.

The idea behind nuget package generation is simple. From the nuget folder execute the PowerShell script which will configure, build and install all combinations of VS versions (2010, 2012, 2013), architectures (Win32, x64) and linkage (static, dynamic). 

Then the package is generated with the CoApp tools. I used a SplitThreshold so that we don't end up with many overlay packages that would need to be installed at build time. 

The nuget package can be used with VS as any package or from CMake by installing the package first as you would on *NIX platforms. See provided README for details.
