### PR TITLE
Define NO_THREADS in when building without threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,7 +318,7 @@ foreach (TYPE IN ITEMS STATIC SHARED)
           PRIVATE "${PROJECT_SOURCE_DIR}/src;${PROJECT_BINARY_DIR}/include/${GFLAGS_INCLUDE_DIR}"
         )
         if (opts MATCHES "nothreads")
-          set (defines "GFLAGS_IS_A_DLL=${GFLAGS_IS_A_DLL};NOTHREADS")
+          set (defines "GFLAGS_IS_A_DLL=${GFLAGS_IS_A_DLL};NO_THREADS")
         else ()
           set (defines "GFLAGS_IS_A_DLL=${GFLAGS_IS_A_DLL}")
           if (CMAKE_USE_PTHREADS_INIT)


### PR DESCRIPTION
Previously NOTHREADS was being defined but the code
in mutex.h checks for NO_THREADS.

This was found with ports gflags to emscripten which doesn't
support threading:
https://chromium.googlesource.com/webports.git/+/9001e2ce36fa7959dbefcd1f3aabcaf4a2de9248/ports/gflags/nacl.patch