### PR TITLE
properly export the .so minor version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ version_numbers (
     PACKAGE_VERSION_PATCH
 )
 
-set (PACKAGE_SOVERSION "${PACKAGE_VERSION_MAJOR}")
+set (PACKAGE_SOVERSION "${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}")
 
 # ----------------------------------------------------------------------------
 # options


### PR DESCRIPTION
This patch has two consequences:
 * previously in lib there would be a file like `libgflags.so.2.2.0` and a symlink named `libgflags.so.2` and `libgflags.so`
 * previously the `SONAME` in the ELF files would be `libgflags.so.2`

This change updates the `SONAME` to `libflags.so.2.2` and adds an extra symlink `libgflags.so.2.2`.

Note that this change is already being done upstream by the Fedora packagers.

**Without This Patch**

```
$ ls lib/
libgflags_nothreads.so  libgflags_nothreads.so.2  libgflags_nothreads.so.2.2.0  libgflags.so  libgflags.so.2  libgflags.so.2.2.0

$ find lib -type f -exec readelf -d {} \; | grep SONAME
 0x000000000000000e (SONAME)             Library soname: [libgflags.so.2]
 0x000000000000000e (SONAME)             Library soname: [libgflags_nothreads.so.2]
```
 
**With This Patch**
 
```
$ ls lib/
libgflags_nothreads.so  libgflags_nothreads.so.2.2  libgflags_nothreads.so.2.2.0  libgflags.so  libgflags.so.2.2  libgflags.so.2.2.0

$ find lib -type f -exec readelf -d {} \; | grep SONAME
 0x000000000000000e (SONAME)             Library soname: [libgflags.so.2.2]
 0x000000000000000e (SONAME)             Library soname: [libgflags_nothreads.so.2.2]
```