### PR TITLE
Fix bazel build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,6 +20,10 @@ cc_library(
     ],
     hdrs = ["gflags.h"],
     copts = [
+        # The config.h gets generated to the package directory of
+        # GENDIR, and we don't want to put it into the includes
+        # otherwise the dependent may pull it in by accident.
+        "-I$(GENDIR)/" + PACKAGE_NAME,
         "-Wno-sign-compare",
         "-DHAVE_STDINT_H",
         "-DHAVE_SYS_TYPES_H",


### PR DESCRIPTION
Add gendir to the include path so that building with bazel doesn't complain config.h can't be found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gflags/gflags/150)
<!-- Reviewable:end -->
