### PR TITLE
Add missing reference symbol to a function parameter.

### DIFF
--- a/src/gflags_completions.cc
+++ b/src/gflags_completions.cc
@@ -122,7 +122,7 @@ static void CategorizeAllMatchingFlags(
     NotableFlags *notable_flags);
 
 static void TryFindModuleAndPackageDir(
-    const vector<CommandLineFlagInfo> all_flags,
+    const vector<CommandLineFlagInfo> &all_flags,
     string *module,
     string *package_dir);
 
@@ -472,7 +472,7 @@ static void PushNameWithSuffix(vector<string>* suffixes, const char* suffix) {
 }
 
 static void TryFindModuleAndPackageDir(
-    const vector<CommandLineFlagInfo> all_flags,
+    const vector<CommandLineFlagInfo> &all_flags,
     string *module,
     string *package_dir) {
   module->clear();


### PR DESCRIPTION
This is quite a trivial change =)

Could you explain please, what is the status of C++11 features in this project? Are they allowed or not?
If the latter, what do you think about using some of C++11\14\17 features?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gflags/gflags/155)
<!-- Reviewable:end -->
