### PR TITLE
Fix incorrect flag value typename for uint32.

### DIFF
--- a/src/gflags.cc
+++ b/src/gflags.cc
@@ -409,7 +409,7 @@ const char* FlagValue::TypeName() const {
   static const char types[] =
       "bool\0xx"
       "int32\0x"
-      "uin32\0x"
+      "uint32\0"
       "int64\0x"
       "uint64\0"
       "double\0"

--- a/test/gflags_unittest.cc
+++ b/test/gflags_unittest.cc
@@ -601,7 +601,7 @@ TEST(SetFlagValueTest, IllegalValues) {
             SetCommandLineOption("test_bool", "12"));
 
   EXPECT_EQ("",
-            SetCommandLineOption("test_uint32", "1970"));
+            SetCommandLineOption("test_uint32", "-1970"));
 
   EXPECT_EQ("",
             SetCommandLineOption("test_int32", "7000000000000"));
@@ -862,7 +862,7 @@ TEST(FlagSaverTest, CanSaveVariousTypedFlagValues) {
   EXPECT_EQ(2, FLAGS_test_uint32);
   EXPECT_EQ(-3, FLAGS_test_int64);
   EXPECT_EQ(4, FLAGS_test_uint64);
-  EXPECT_DOUBLE_EQ(4.0, FLAGS_test_double);
+  EXPECT_DOUBLE_EQ(5.0, FLAGS_test_double);
   EXPECT_EQ("good", FLAGS_test_string);
 }
 


### PR DESCRIPTION
Hi!

While playing with the code I discovered that typename for uint32 was declared with a typo.
Also I fixed some unittests related to that.

PTAL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gflags/gflags/156)
<!-- Reviewable:end -->
