### PR TITLE
Enable Travis CI for Linux and OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,7 @@ dist: trusty
 language: cpp
 
 script:
-  - mkdir build && cd build
-  - cmake -DGFLAGS_BUILD_TESTING=True ..
-  - make
-  - ctest
+  - mkdir out && cd out && cmake -DGFLAGS_BUILD_TESTING=True .. && make && ctest
 
 compiler:
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+os:
+  - linux
+  - osx
+
+# Ubuntu 14.04 Trusty support, to get newer cmake and compilers.
+sudo: required
+dist: trusty
+
+language: cpp
+
+script:
+  - mkdir out && cd out
+  - cmake -DGFLAGS_BUILD_TESTING=True ..
+  - make
+  - ctest
+
+compiler:
+  - clang
+  - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ dist: trusty
 language: cpp
 
 script:
-  - mkdir out && cd out
+  - mkdir build && cd build
   - cmake -DGFLAGS_BUILD_TESTING=True ..
   - make
   - ctest


### PR DESCRIPTION
This a part of #159
It should test that the library and tests can be builded and CMake based tests can pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gflags/gflags/160)
<!-- Reviewable:end -->
