### PR TITLE
Add initial AppVeyor config.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+# Configuration for continuous integration service at appveyor.com
+
+shallow_clone: true
+
+# Operating system (build VM template)
+os: Visual Studio 2015
+
+# scripts that are called at very beginning, before repo cloning
+init:
+
+# clone directory
+clone_folder: c:\projects\gflags
+
+matrix:
+  fast_finish: true
+
+install:
+  # show all available env vars
+  - set
+  - echo cmake on AppVeyor
+  - cmake -version
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
+
+build_script:
+  - cd c:\projects\gflags
+  - mkdir out && cd out
+  - cmake -G "Visual Studio 14 2015"
+    -DCMAKE_BUILD_TYPE=Release
+    -DGFLAGS_BUILD_TESTING=True
+    ..
+  - msbuild gflags.sln /toolsversion:14.0 /p:PlatformToolset=v140


### PR DESCRIPTION
Hi!

This is another part of #159 issue.
Project https://ci.appveyor.com/ is like Travis, but for Windows only.
It requires to login and add a project from Github like Travis does.

I've failed to run tests there for Release build (not sure why ATM), but it can build from sources, for example see logs https://ci.appveyor.com/project/dreamer-dead/gflags

When I will fix my Windows build machine with new WinSDK 10, I can make further improvements on this config.
PTAL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gflags/gflags/161)
<!-- Reviewable:end -->
