### PR TITLE
Remove filter for excluded tests from AppVeyor config.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,4 @@ build_script:
   - cmake --build . --config %configuration%
 
 test_script:
-  # strip_flags_binary test currently fails on AppVeyor in Debug configuration.
-  - IF %configuration%==Debug SET GFLAGS_EXCLUDED_TESTS=strip_flags_binary
-  - ctest -C %configuration% -E %GFLAGS_EXCLUDED_TESTS%
+  - ctest -C %configuration%


### PR DESCRIPTION
After your changes in #163 , it is possible to clean out tests filter.
It seems that #159 can be closed after merging this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gflags/gflags/165)
<!-- Reviewable:end -->
