### PR TITLE
Fix Windows linker errors and warnings.

### DIFF
--- a/src/gflags.cc
+++ b/src/gflags.cc
@@ -96,6 +96,7 @@
 #if defined(HAVE_FNMATCH_H)
 #  include <fnmatch.h>
 #elif defined(HAVE_SHLWAPI_H)
+#  define NO_SHLWAPI_ISOS
 #  include <shlwapi.h>
 #endif
 #include <stdarg.h> // For va_list and related operations
@@ -1467,7 +1468,7 @@ FlagRegisterer::FlagRegisterer(const char* name,
 
 // Force compiler to generate code for the given template specialization.
 #define INSTANTIATE_FLAG_REGISTERER_CTOR(type)                  \
-  template FlagRegisterer::FlagRegisterer(                      \
+  template GFLAGS_DLL_DECL FlagRegisterer::FlagRegisterer(                      \
       const char* name, const char* help, const char* filename, \
       type* current_storage, type* defvalue_storage)
 

--- a/src/gflags.cc
+++ b/src/gflags.cc
@@ -1468,7 +1468,7 @@ FlagRegisterer::FlagRegisterer(const char* name,
 
 // Force compiler to generate code for the given template specialization.
 #define INSTANTIATE_FLAG_REGISTERER_CTOR(type)                  \
-  template GFLAGS_DLL_DECL FlagRegisterer::FlagRegisterer(                      \
+  template GFLAGS_DLL_DECL FlagRegisterer::FlagRegisterer(      \
       const char* name, const char* help, const char* filename, \
       type* current_storage, type* defvalue_storage)
 

--- a/src/gflags_declare.h.in
+++ b/src/gflags_declare.h.in
@@ -56,7 +56,7 @@
 
 // We always want to import variables declared in user code
 #ifndef GFLAGS_DLL_DECLARE_FLAG
-#  ifdef _MSC_VER
+#  if @GFLAGS_IS_A_DLL@ && defined(_MSC_VER)
 #    define GFLAGS_DLL_DECLARE_FLAG __declspec(dllimport)
 #  else
 #    define GFLAGS_DLL_DECLARE_FLAG


### PR DESCRIPTION
Hi!

It is a fix to shared library build.
Unfortunately, I missed `GFLAGS_DLL_DECL` attribute for templates =(
It seems that we need a shared build configuration on CI server.

Also, I tried to fix some compiler and linker warnings,
- about OS_WINDOWS, because shlwapi.h header also can define it (but can be avoided).
- about warning LNK4217: locally defined symbol FLAGS_tryfromenv. I saw that you fixed that some time ago, but I had this warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gflags/gflags/166)
<!-- Reviewable:end -->
