### PR TITLE
Fix unsigned comparison error in gflags_reporting.cc

### DIFF
--- a/src/gflags_reporting.cc
+++ b/src/gflags_reporting.cc
@@ -122,11 +122,12 @@ string DescribeOneFlag(const CommandLineFlagInfo& flag) {
                 flag.name.c_str(),
                 flag.description.c_str());
   const char* c_string = main_part.c_str();
-  size_t chars_left = main_part.length();
+  int chars_left = main_part.length();
   string final_string = "";
   int chars_in_line = 0;  // how many chars in current line so far?
   while (1) {
-    assert(chars_left == strlen(c_string));  // Unless there's a \0 in there?
+    assert(static_cast<size_t>(chars_left)
+            == strlen(c_string));  // Unless there's a \0 in there?
     const char* newline = strchr(c_string, '\n');
     if (newline == NULL && chars_in_line+chars_left < kLineLength) {
       // The whole remainder of the string fits on this line

--- a/src/gflags_reporting.cc
+++ b/src/gflags_reporting.cc
@@ -122,7 +122,7 @@ string DescribeOneFlag(const CommandLineFlagInfo& flag) {
                 flag.name.c_str(),
                 flag.description.c_str());
   const char* c_string = main_part.c_str();
-  int chars_left = main_part.length();
+  int chars_left = static_cast<int>(main_part.length());
   string final_string = "";
   int chars_in_line = 0;  // how many chars in current line so far?
   while (1) {

--- a/src/gflags_reporting.cc
+++ b/src/gflags_reporting.cc
@@ -122,7 +122,7 @@ string DescribeOneFlag(const CommandLineFlagInfo& flag) {
                 flag.name.c_str(),
                 flag.description.c_str());
   const char* c_string = main_part.c_str();
-  int chars_left = static_cast<int>(main_part.length());
+  size_t chars_left = main_part.length();
   string final_string = "";
   int chars_in_line = 0;  // how many chars in current line so far?
   while (1) {


### PR DESCRIPTION
A line in `gflags_reporting.cc` was causing an error on building with `-Werror` because of signed and unsigned integral comparisons.  This commit fixed that by declaring the integer used for length comparisons to be unsigned and of type `size_t`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gflags/gflags/168)
<!-- Reviewable:end -->
