### PR TITLE
Fix error messages to not truncate to 255 characters

### DIFF
--- a/src/gflags.cc
+++ b/src/gflags.cc
@@ -171,12 +171,10 @@ enum DieWhenReporting { DIE, DO_NOT_DIE };
 
 // Report Error and exit if requested.
 static void ReportError(DieWhenReporting should_die, const char* format, ...) {
-  char error_message[255];
   va_list ap;
   va_start(ap, format);
-  vsnprintf(error_message, sizeof(error_message), format, ap);
+  vfprintf(stderr, format, ap);
   va_end(ap);
-  fprintf(stderr, "%s", error_message);
   fflush(stderr);   // should be unnecessary, but cygwin's rxvt buffers stderr
   if (should_die == DIE) gflags_exitfunc(1);
 }


### PR DESCRIPTION
I noticed that error messages from GFlags were being truncated, and it
turns out the code limits it to 255 characters. This removes the 255 char
buffer and prints directly to stderr.

I also couldn't find any justification in the commit that introduced this char
[buf](https://github.com/gflags/gflags/commit/917f4e7bf3c36b4c56a77faca639758d3aca2a92#diff-6a83ed5fb1a483481f248c62830bb566R180).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gflags/gflags/175)
<!-- Reviewable:end -->
