### PR TITLE
Change the Bazel BUILD rule

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -37,9 +37,6 @@ cc_library(
         "-DHAVE_RWLOCK",
         "-DGFLAGS_INTTYPES_FORMAT_C99",
     ],
-    includes = [
-        "include",
-    ],
     visibility = ["//visibility:public"],
 )
 

--- a/BUILD
+++ b/BUILD
@@ -70,7 +70,7 @@ genrule(
     outs = [
         "gflags_completions.h",
     ],
-    cmd = "awk '{ gsub(/@GFLAGS_NAMESPACE@/, \"google\"); print; }' $(<) > $(@)",
+    cmd = "awk '{ gsub(/@GFLAGS_NAMESPACE@/, \"gflags\"); print; }' $(<) > $(@)",
 )
 
 genrule(
@@ -82,7 +82,7 @@ genrule(
         "gflags_declare.h",
     ],
     cmd = ("awk '{ " +
-           "gsub(/@GFLAGS_NAMESPACE@/, \"google\"); " +
+           "gsub(/@GFLAGS_NAMESPACE@/, \"gflags\"); " +
            "gsub(/@(HAVE_STDINT_H|HAVE_SYS_TYPES_H|HAVE_INTTYPES_H|GFLAGS_INTTYPES_FORMAT_C99)@/, \"1\"); " +
            "gsub(/@([A-Z0-9_]+)@/, \"0\"); " +
            "print; }' $(<) > $(@)"),

--- a/BUILD
+++ b/BUILD
@@ -70,7 +70,7 @@ genrule(
     outs = [
         "gflags_completions.h",
     ],
-    cmd = "awk '{ gsub(/@GFLAGS_NAMESPACE@/, \"gflags\"); print; }' $(<) > $(@)",
+    cmd = "awk '{ gsub(/@GFLAGS_NAMESPACE@/, \"google\"); print; }' $(<) > $(@)",
 )
 
 genrule(
@@ -82,7 +82,7 @@ genrule(
         "gflags_declare.h",
     ],
     cmd = ("awk '{ " +
-           "gsub(/@GFLAGS_NAMESPACE@/, \"gflags\"); " +
+           "gsub(/@GFLAGS_NAMESPACE@/, \"google\"); " +
            "gsub(/@(HAVE_STDINT_H|HAVE_SYS_TYPES_H|HAVE_INTTYPES_H|GFLAGS_INTTYPES_FORMAT_C99)@/, \"1\"); " +
            "gsub(/@([A-Z0-9_]+)@/, \"0\"); " +
            "print; }' $(<) > $(@)"),

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,12 +33,12 @@ the name of this package and the obtained version of the software.
     $ cd gflags-$version
     $ mkdir build && cd build
     $ ccmake ..
-    
+
       - Press 'c' to configure the build system and 'e' to ignore warnings.
       - Set CMAKE_INSTALL_PREFIX and other CMake variables and options.
       - Continue pressing 'c' until the option 'g' is available.
       - Then press 'g' to generate the configuration files for GNU Make.
-    
+
     $ make
     $ make test    (optional)
     $ make install (optional)
@@ -73,14 +73,14 @@ To use gflags in a Bazel project, map it in as an external dependency by editing
 your WORKSPACE file:
 
     git_repository(
-        name = "gflags_git",
+        name = "com_googlesource_code_gflags",
         commit = "",  # Use the current HEAD commit
         remote = "https://github.com/gflags/gflags.git",
     )
 
     bind(
         name = "gflags",
-        actual = "@gflags_git//:gflags",
+        actual = "@com_googlesource_code_gflags//:gflags",
     )
 
 You can then add `//external:gflags` to the `deps` section of a `cc_binary` or

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "com_googlesource_code_gflags")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,1 +1,0 @@
-workspace(name = "com_googlesource_code_gflags")


### PR DESCRIPTION
The one in the HEAD is missing the WORKSPACE file.
Also set the repository name to "com_googlesource_code_gflags". RE2 uses this style of name.
