### PR TITLE
enh: Add option to add installation to CMake’s package registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,8 @@ gflags_define (BOOL BUILD_TESTING              "Enable build of the unit tests a
 gflags_define (BOOL INSTALL_HEADERS            "Request installation of headers and other development files."             ON  OFF)
 gflags_define (BOOL INSTALL_SHARED_LIBS        "Request installation of shared libraries."                                ON  ON)
 gflags_define (BOOL INSTALL_STATIC_LIBS        "Request installation of static libraries."                                ON  OFF)
+gflags_define (BOOL REGISTER_BUILD_DIR         "Request entry of build directory in CMake's package registry."            OFF OFF)
+gflags_define (BOOL REGISTER_INSTALL_PREFIX    "Request entry of installed package in CMake's package registry."          ON  OFF)
 
 gflags_property (BUILD_STATIC_LIBS   ADVANCED TRUE)
 gflags_property (INSTALL_HEADERS     ADVANCED TRUE)
@@ -523,7 +525,12 @@ endif ()
 # support direct use of build tree
 set (INSTALL_PREFIX_REL2CONFIG_DIR .)
 export (TARGETS ${TARGETS} FILE "${PROJECT_BINARY_DIR}/${EXPORT_NAME}.cmake")
-export (PACKAGE gflags)
+if (REGISTER_BUILD_DIR)
+  export (PACKAGE ${PACKAGE_NAME})
+endif ()
+if (REGISTER_INSTALL_PREFIX)
+  register_gflags_package(${CONFIG_INSTALL_DIR})
+endif ()
 configure_file (cmake/config.cmake.in "${PROJECT_BINARY_DIR}/${PACKAGE_NAME}-config.cmake" @ONLY)
 
 # ----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,10 @@ endif ()
 # prefix for package variables in CMake configuration file
 string (TOUPPER "${PACKAGE_NAME}" PACKAGE_PREFIX)
 
+# convert file path on Windows with back slashes to path with forward slashes
+# otherwise this causes an issue with the cmake_install.cmake script
+file (TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}" CMAKE_INSTALL_PREFIX)
+
 # ----------------------------------------------------------------------------
 # options
 
@@ -196,6 +200,7 @@ endif ()
 
 gflags_define (STRING INCLUDE_DIR "Name of include directory of installed header files relative to CMAKE_INSTALL_PREFIX/include/" "${PACKAGE_NAME}")
 gflags_property (INCLUDE_DIR ADVANCED TRUE)
+file (TO_CMAKE_PATH "${INCLUDE_DIR}" INCLUDE_DIR)
 if (IS_ABSOLUTE INCLUDE_DIR)
   message (FATAL_ERROR "[GFLAGS_]INCLUDE_DIR must be a path relative to CMAKE_INSTALL_PREFIX/include/")
 endif ()


### PR DESCRIPTION
As discussed in #174, by default add path to `gflags-config.cmake` of installation in `CMAKE_INSTALL_PREFIX` to CMake's user package registry instead of the build directory.