### PR TITLE
enh: Rename private sources, include public headers with rel path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,8 +348,8 @@ set (PRIVATE_HDRS
 
 set (GFLAGS_SRCS
   "gflags.cc"
-  "gflags_reporting.cc"
-  "gflags_completions.cc"
+  "reporting.cc"
+  "completions.cc"
 )
 
 if (OS_WINDOWS)

--- a/src/completions.cc
+++ b/src/completions.cc
@@ -46,11 +46,6 @@
 //     5a) Force bash to place most-relevent groups at the top of the list
 //     5b) Trim most flag's descriptions to fit on a single terminal line
 
-
-#include "gflags_completions.h"
-
-#include "config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>   // for strlen
@@ -60,8 +55,11 @@
 #include <utility>
 #include <vector>
 
-#include "gflags.h"
+#include "config.h"
 #include "util.h"
+
+#include "gflags/gflags.h"
+#include "gflags/gflags_completions.h"
 
 using std::set;
 using std::string;

--- a/src/gflags.cc
+++ b/src/gflags.cc
@@ -88,7 +88,7 @@
 // are, similarly, mostly hooks into the functionality described above.
 
 #include "config.h"
-#include "gflags.h"
+#include "gflags/gflags.h"
 
 #include <assert.h>
 #include <ctype.h>

--- a/src/gflags.h.in
+++ b/src/gflags.h.in
@@ -81,7 +81,7 @@
 #include <string>
 #include <vector>
 
-#include "gflags_declare.h" // IWYU pragma: export
+#include "gflags/gflags_declare.h" // IWYU pragma: export
 
 
 // We always want to export variables defined in user code

--- a/src/mutex.h
+++ b/src/mutex.h
@@ -106,7 +106,7 @@
 #ifndef GFLAGS_MUTEX_H_
 #define GFLAGS_MUTEX_H_
 
-#include "gflags_declare.h"     // to figure out pthreads support
+#include "gflags/gflags_declare.h"     // to figure out pthreads support
 
 #if defined(NO_THREADS)
   typedef int MutexType;        // to keep a lock-count

--- a/src/reporting.cc
+++ b/src/reporting.cc
@@ -56,8 +56,8 @@
 #include <vector>
 
 #include "config.h"
-#include "gflags.h"
-#include "gflags_completions.h"
+#include "gflags/gflags.h"
+#include "gflags/gflags_completions.h"
 #include "util.h"
 
 

--- a/src/util.h
+++ b/src/util.h
@@ -35,6 +35,7 @@
 #define GFLAGS_UTIL_H_
 
 #include "config.h"
+#include "gflags/gflags_declare.h" // GFLAGS_NAMESPACE
 
 #include <assert.h>
 #ifdef HAVE_INTTYPES_H


### PR DESCRIPTION
Minor change. Just rename some `.cc` files to get rid of obsolete `gflags_` prefix. Still needed for public headers, though, in case these are in a namespace / include directory not exclusive to the gflags library (e.g., `google/`).