### PR TITLE
Revert "enh: Rename private sources, include public headers with rel path"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,8 +350,8 @@ set (PRIVATE_HDRS
 
 set (GFLAGS_SRCS
   "gflags.cc"
-  "reporting.cc"
-  "completions.cc"
+  "gflags_reporting.cc"
+  "gflags_completions.cc"
 )
 
 if (OS_WINDOWS)

--- a/src/gflags.cc
+++ b/src/gflags.cc
@@ -88,7 +88,7 @@
 // are, similarly, mostly hooks into the functionality described above.
 
 #include "config.h"
-#include "gflags/gflags.h"
+#include "gflags.h"
 
 #include <assert.h>
 #include <ctype.h>

--- a/src/gflags.h.in
+++ b/src/gflags.h.in
@@ -81,7 +81,7 @@
 #include <string>
 #include <vector>
 
-#include "gflags/gflags_declare.h" // IWYU pragma: export
+#include "gflags_declare.h" // IWYU pragma: export
 
 
 // We always want to export variables defined in user code

--- a/src/gflags_completions.cc
+++ b/src/gflags_completions.cc
@@ -46,6 +46,11 @@
 //     5a) Force bash to place most-relevent groups at the top of the list
 //     5b) Trim most flag's descriptions to fit on a single terminal line
 
+
+#include "gflags_completions.h"
+
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>   // for strlen
@@ -55,11 +60,8 @@
 #include <utility>
 #include <vector>
 
-#include "config.h"
+#include "gflags.h"
 #include "util.h"
-
-#include "gflags/gflags.h"
-#include "gflags/gflags_completions.h"
 
 using std::set;
 using std::string;

--- a/src/gflags_reporting.cc
+++ b/src/gflags_reporting.cc
@@ -56,8 +56,8 @@
 #include <vector>
 
 #include "config.h"
-#include "gflags/gflags.h"
-#include "gflags/gflags_completions.h"
+#include "gflags.h"
+#include "gflags_completions.h"
 #include "util.h"
 
 

--- a/src/mutex.h
+++ b/src/mutex.h
@@ -106,7 +106,7 @@
 #ifndef GFLAGS_MUTEX_H_
 #define GFLAGS_MUTEX_H_
 
-#include "gflags/gflags_declare.h"     // to figure out pthreads support
+#include "gflags_declare.h"     // to figure out pthreads support
 
 #if defined(NO_THREADS)
   typedef int MutexType;        // to keep a lock-count

--- a/src/util.h
+++ b/src/util.h
@@ -35,7 +35,6 @@
 #define GFLAGS_UTIL_H_
 
 #include "config.h"
-#include "gflags/gflags_declare.h" // GFLAGS_NAMESPACE
 
 #include <assert.h>
 #ifdef HAVE_INTTYPES_H


### PR DESCRIPTION
Ok, just figured through the failing tests that it is desirable to have the reporting module called `gflags_reporting.cc` in the help output... gflags is just so different from other command-line parsing libraries...

Reverts gflags/gflags#190