### PR TITLE
enh: Bazel BUILD, add WORKSPACE file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,106 +1,12 @@
-# Bazel build file for gflags
+# Bazel (http://bazel.io/) BUILD file for gflags.
 #
 # See INSTALL.md for instructions for adding gflags to a Bazel workspace.
 
 licenses(["notice"])
 
-cc_library(
-    name = "gflags",
-    srcs = [
-        "src/gflags.cc",
-        "src/gflags_completions.cc",
-        "src/gflags_reporting.cc",
-        "src/mutex.h",
-        "src/util.h",
-        ":config_h",
-        ":gflags_completions_h",
-        ":gflags_declare_h",
-        ":gflags_h",
-        ":includes",
-    ],
-    hdrs = ["gflags.h"],
-    copts = [
-        # The config.h gets generated to the package directory of
-        # GENDIR, and we don't want to put it into the includes
-        # otherwise the dependent may pull it in by accident.
-        "-I$(GENDIR)/" + PACKAGE_NAME,
-        "-Wno-sign-compare",
-        "-DHAVE_STDINT_H",
-        "-DHAVE_SYS_TYPES_H",
-        "-DHAVE_INTTYPES_H",
-        "-DHAVE_SYS_STAT_H",
-        "-DHAVE_UNISTD_H",
-        "-DHAVE_FNMATCH_H",
-        "-DHAVE_STRTOLL",
-        "-DHAVE_STRTOQ",
-        "-DHAVE_PTHREAD",
-        "-DHAVE_RWLOCK",
-        "-DGFLAGS_INTTYPES_FORMAT_C99",
-    ],
-    includes = [
-        "include",
-    ],
-    linkopts = ["-lpthread"],
-    visibility = ["//visibility:public"],
-)
+exports_files(["src/gflags_complections.sh", "COPYING.txt"])
 
-genrule(
-    name = "config_h",
-    srcs = [
-        "src/config.h.in",
-    ],
-    outs = [
-        "config.h",
-    ],
-    cmd = "awk '{ gsub(/^#cmakedefine/, \"//cmakedefine\"); print; }' $(<) > $(@)",
-)
-
-genrule(
-    name = "gflags_h",
-    srcs = [
-        "src/gflags.h.in",
-    ],
-    outs = [
-        "gflags.h",
-    ],
-    cmd = "awk '{ gsub(/@(GFLAGS_ATTRIBUTE_UNUSED|INCLUDE_GFLAGS_NS_H)@/, \"\"); print; }' $(<) > $(@)",
-)
-
-genrule(
-    name = "gflags_completions_h",
-    srcs = [
-        "src/gflags_completions.h.in",
-    ],
-    outs = [
-        "gflags_completions.h",
-    ],
-    cmd = "awk '{ gsub(/@GFLAGS_NAMESPACE@/, \"gflags\"); print; }' $(<) > $(@)",
-)
-
-genrule(
-    name = "gflags_declare_h",
-    srcs = [
-        "src/gflags_declare.h.in",
-    ],
-    outs = [
-        "gflags_declare.h",
-    ],
-    cmd = ("awk '{ " +
-           "gsub(/@GFLAGS_NAMESPACE@/, \"gflags\"); " +
-           "gsub(/@(HAVE_STDINT_H|HAVE_SYS_TYPES_H|HAVE_INTTYPES_H|GFLAGS_INTTYPES_FORMAT_C99)@/, \"1\"); " +
-           "gsub(/@([A-Z0-9_]+)@/, \"0\"); " +
-           "print; }' $(<) > $(@)"),
-)
-
-genrule(
-    name = "includes",
-    srcs = [
-        ":gflags_h",
-        ":gflags_declare_h",
-    ],
-    outs = [
-        "include/gflags/gflags.h",
-        "include/gflags/gflags_declare.h",
-    ],
-    cmd = "mkdir -p $(@D)/include/gflags && cp $(SRCS) $(@D)/include/gflags",
-)
+load(":bazel/gflags.bzl", "gflags_sources", "gflags_library")
+(hdrs, srcs) = gflags_sources(namespace=["gflags", "google"])
+gflags_library(hdrs=hdrs, srcs=srcs, threads=0)
+gflags_library(hdrs=hdrs, srcs=srcs, threads=1)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,6 @@
+# Copyright 2006 Google Inc.  All Rights Reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the COPYING.txt file.
+
+# Bazel (http://bazel.io/) WORKSPACE file for gflags.
+workspace(name="com_github_gflags_gflags")

--- a/bazel/gflags.bzl
+++ b/bazel/gflags.bzl
@@ -1,0 +1,92 @@
+# ------------------------------------------------------------------------------
+# Add native rules to configure source files
+def gflags_sources(namespace=["google", "gflags"]):
+    native.genrule(
+        name = "config_h",
+        srcs = ["src/config.h.in"],
+        outs = ["config.h"],
+        cmd  = "awk '{ gsub(/^#cmakedefine/, \"//cmakedefine\"); print; }' $(<) > $(@)"
+    )
+    native.genrule(
+        name = "gflags_declare_h",
+        srcs = ["src/gflags_declare.h.in"],
+        outs = ["gflags/gflags_declare.h"],
+        cmd  = ("awk '{ " +
+                "gsub(/@GFLAGS_NAMESPACE@/, \"" + namespace[0] + "\"); " +
+                "gsub(/@(HAVE_STDINT_H|HAVE_SYS_TYPES_H|HAVE_INTTYPES_H|GFLAGS_INTTYPES_FORMAT_C99)@/, \"1\"); " +
+                "gsub(/@([A-Z0-9_]+)@/, \"0\"); " +
+                "print; }' $(<) > $(@)")
+    )
+    gflags_ns_h_files = []
+    for ns in namespace[1:]:
+        gflags_ns_h_file = "gflags_{}.h".format(ns)
+        native.genrule(
+            name = gflags_ns_h_file.replace('.', '_'),
+            srcs = ["src/gflags_ns.h.in"],
+            outs = ["gflags/" + gflags_ns_h_file],
+            cmd  = ("awk '{ " +
+                    "gsub(/@ns@/, \"" + ns + "\"); " +
+                    "gsub(/@NS@/, \"" + ns.upper() + "\"); " +
+                    "print; }' $(<) > $(@)")
+        )
+        gflags_ns_h_files.append(gflags_ns_h_file)
+    native.genrule(
+        name = "gflags_h",
+        srcs = ["src/gflags.h.in"],
+        outs = ["gflags/gflags.h"],
+        cmd  = ("awk '{ " +
+                "gsub(/@GFLAGS_ATTRIBUTE_UNUSED@/, \"\"); " +
+                "gsub(/@INCLUDE_GFLAGS_NS_H@/, \"" + '\n'.join(["#include \\\"gflags/{}\\\"".format(hdr) for hdr in gflags_ns_h_files]) + "\"); " +
+                "print; }' $(<) > $(@)")
+    )
+    native.genrule(
+        name = "gflags_completions_h",
+        srcs = ["src/gflags_completions.h.in"],
+        outs = ["gflags/gflags_completions.h"],
+        cmd  = "awk '{ gsub(/@GFLAGS_NAMESPACE@/, \"" + namespace[0] + "\"); print; }' $(<) > $(@)"
+    )
+    hdrs = [":gflags_h", ":gflags_declare_h", ":gflags_completions_h"]
+    hdrs.extend([':' + hdr.replace('.', '_') for hdr in gflags_ns_h_files])
+    srcs = [
+        ":config_h",
+        "src/gflags.cc",
+        "src/gflags_completions.cc",
+        "src/gflags_reporting.cc",
+        "src/mutex.h",
+        "src/util.h"
+    ]
+    return [hdrs, srcs]
+
+# ------------------------------------------------------------------------------
+# Add native rule to build gflags library
+def gflags_library(hdrs=[], srcs=[], threads=1):
+    name = "gflags"
+    copts = [
+        "-DHAVE_STDINT_H",
+        "-DHAVE_SYS_TYPES_H",
+        "-DHAVE_INTTYPES_H",
+        "-DHAVE_SYS_STAT_H",
+        "-DHAVE_UNISTD_H",
+        "-DHAVE_FNMATCH_H",
+        "-DHAVE_STRTOLL",
+        "-DHAVE_STRTOQ",
+        "-DHAVE_PTHREAD",
+        "-DHAVE_RWLOCK",
+        "-DGFLAGS_INTTYPES_FORMAT_C99",
+        "-DGFLAGS_IS_A_DLL=0",
+    ]
+    linkopts = []
+    if threads:
+        linkopts.append("-lpthread")
+    else:
+        name += "_nothreads"
+        copts.append("-DNO_THREADS")
+    native.cc_library(
+        name       = name,
+        hdrs       = hdrs,
+        srcs       = srcs,
+        includes   = ["$(GENDIR)"],
+        copts      = copts,
+        linkopts   = linkopts,
+        visibility = ["//visibility:public"]
+    )

--- a/src/gflags.cc
+++ b/src/gflags.cc
@@ -88,7 +88,7 @@
 // are, similarly, mostly hooks into the functionality described above.
 
 #include "config.h"
-#include "gflags.h"
+#include "gflags/gflags.h"
 
 #include <assert.h>
 #include <ctype.h>

--- a/src/gflags.h.in
+++ b/src/gflags.h.in
@@ -81,7 +81,7 @@
 #include <string>
 #include <vector>
 
-#include "gflags_declare.h" // IWYU pragma: export
+#include "gflags/gflags_declare.h" // IWYU pragma: export
 
 
 // We always want to export variables defined in user code

--- a/src/gflags_completions.cc
+++ b/src/gflags_completions.cc
@@ -46,11 +46,6 @@
 //     5a) Force bash to place most-relevent groups at the top of the list
 //     5b) Trim most flag's descriptions to fit on a single terminal line
 
-
-#include "gflags_completions.h"
-
-#include "config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>   // for strlen
@@ -60,7 +55,9 @@
 #include <utility>
 #include <vector>
 
-#include "gflags.h"
+#include "config.h"
+#include "gflags/gflags.h"
+#include "gflags/gflags_completions.h"
 #include "util.h"
 
 using std::set;

--- a/src/gflags_reporting.cc
+++ b/src/gflags_reporting.cc
@@ -56,8 +56,8 @@
 #include <vector>
 
 #include "config.h"
-#include "gflags.h"
-#include "gflags_completions.h"
+#include "gflags/gflags.h"
+#include "gflags/gflags_completions.h"
 #include "util.h"
 
 

--- a/src/mutex.h
+++ b/src/mutex.h
@@ -106,7 +106,7 @@
 #ifndef GFLAGS_MUTEX_H_
 #define GFLAGS_MUTEX_H_
 
-#include "gflags_declare.h"     // to figure out pthreads support
+#include "gflags/gflags_declare.h"     // to figure out pthreads support
 
 #if defined(NO_THREADS)
   typedef int MutexType;        // to keep a lock-count


### PR DESCRIPTION
Refactored Bazel BUILD rules:
- Added `gflags_nothreads` target.
- Added rules to generate `gflags/gflags_google.h` header file with symbols imported into `google` namespace to maintain backwards compatibility (for now).
- Include public header files using interface include path, e.g., `gflags/gflags.h`, in all files.
- Added `WORKSPACE` file as suggested by @yasushi-saito  in #181.

Verify before merge:
- [x] Check Bazel build on Ubuntu 14.04.
- [x] Check Bazel build on macOS 10.12.
- ~~Check Bazel build on Windows 7.~~

Closes #153, #179.