### PR TITLE
fix: Include utils by file instead of CMAKE_MODULE_PATH search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,8 +78,7 @@ endif ()
 
 # ----------------------------------------------------------------------------
 # includes
-set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-include (utils)
+include ("${CMAKE_CURRENT_SOURCE_DIR}/cmake/utils.cmake")
 
 # ----------------------------------------------------------------------------
 # package information


### PR DESCRIPTION
Leave `CMAKE_MODULE_PATH` for users to define where `find_package` modules are.