### PR TITLE
Move GENDIR from includes back to copts

### DIFF
--- a/bazel/gflags.bzl
+++ b/bazel/gflags.bzl
@@ -62,6 +62,7 @@ def gflags_sources(namespace=["google", "gflags"]):
 def gflags_library(hdrs=[], srcs=[], threads=1):
     name = "gflags"
     copts = [
+        "-I$(GENDIR)/" + PACKAGE_NAME,
         "-DHAVE_STDINT_H",
         "-DHAVE_SYS_TYPES_H",
         "-DHAVE_INTTYPES_H",
@@ -85,7 +86,6 @@ def gflags_library(hdrs=[], srcs=[], threads=1):
         name       = name,
         hdrs       = hdrs,
         srcs       = srcs,
-        includes   = ["$(GENDIR)"],
         copts      = copts,
         linkopts   = linkopts,
         visibility = ["//visibility:public"]


### PR DESCRIPTION
Hi, Bazel build fails both on v2.2.0 and on master stating that it can't find `src/config.h` file.

It seems like [this commit](https://github.com/gflags/gflags/commit/37e2867) accidentally undid [this fix](https://github.com/gflags/gflags/commit/7ae23fd). Putting GENDIR into `includes` doesn't seem to work, even when I tried doing that straight from [the fix commit](https://github.com/gflags/gflags/commit/7ae23fd).

Moving GENDIR include from `includes` to `copts` fixed the issue for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gflags/gflags/199)
<!-- Reviewable:end -->
