### PR TITLE
Changed include directory in bazel build

### DIFF
--- a/bazel/gflags.bzl
+++ b/bazel/gflags.bzl
@@ -10,7 +10,7 @@ def gflags_sources(namespace=["google", "gflags"]):
     native.genrule(
         name = "gflags_declare_h",
         srcs = ["src/gflags_declare.h.in"],
-        outs = ["gflags/gflags_declare.h"],
+        outs = ["include/gflags/gflags_declare.h"],
         cmd  = ("awk '{ " +
                 "gsub(/@GFLAGS_NAMESPACE@/, \"" + namespace[0] + "\"); " +
                 "gsub(/@(HAVE_STDINT_H|HAVE_SYS_TYPES_H|HAVE_INTTYPES_H|GFLAGS_INTTYPES_FORMAT_C99)@/, \"1\"); " +
@@ -23,7 +23,7 @@ def gflags_sources(namespace=["google", "gflags"]):
         native.genrule(
             name = gflags_ns_h_file.replace('.', '_'),
             srcs = ["src/gflags_ns.h.in"],
-            outs = ["gflags/" + gflags_ns_h_file],
+            outs = ["include/gflags/" + gflags_ns_h_file],
             cmd  = ("awk '{ " +
                     "gsub(/@ns@/, \"" + ns + "\"); " +
                     "gsub(/@NS@/, \"" + ns.upper() + "\"); " +
@@ -33,7 +33,7 @@ def gflags_sources(namespace=["google", "gflags"]):
     native.genrule(
         name = "gflags_h",
         srcs = ["src/gflags.h.in"],
-        outs = ["gflags/gflags.h"],
+        outs = ["include/gflags/gflags.h"],
         cmd  = ("awk '{ " +
                 "gsub(/@GFLAGS_ATTRIBUTE_UNUSED@/, \"\"); " +
                 "gsub(/@INCLUDE_GFLAGS_NS_H@/, \"" + '\n'.join(["#include \\\"gflags/{}\\\"".format(hdr) for hdr in gflags_ns_h_files]) + "\"); " +
@@ -42,7 +42,7 @@ def gflags_sources(namespace=["google", "gflags"]):
     native.genrule(
         name = "gflags_completions_h",
         srcs = ["src/gflags_completions.h.in"],
-        outs = ["gflags/gflags_completions.h"],
+        outs = ["include/gflags/gflags_completions.h"],
         cmd  = "awk '{ gsub(/@GFLAGS_NAMESPACE@/, \"" + namespace[0] + "\"); print; }' $(<) > $(@)"
     )
     hdrs = [":gflags_h", ":gflags_declare_h", ":gflags_completions_h"]
@@ -85,7 +85,7 @@ def gflags_library(hdrs=[], srcs=[], threads=1):
         name       = name,
         hdrs       = hdrs,
         srcs       = srcs,
-        includes   = ["$(GENDIR)"],
+        includes   = ["include/"],
         copts      = copts,
         linkopts   = linkopts,
         visibility = ["//visibility:public"]


### PR DESCRIPTION
If you don't do this, importing as an external repo doesn't work properly.

In the current version I ended up with system include lines like this:
-isystem bazel-out/local_linux-opt/genfiles/external/gflags/bazel-out/local_linux-opt/genfiles

which is not correct.