### PR TITLE
Adding support for not showing internal gflags help

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,13 @@ file (TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}" CMAKE_INSTALL_PREFIX)
 # ----------------------------------------------------------------------------
 # options
 
+OPTION(GFLAGS_STRIP_INTERNAL_FLAG_HELP "Hide help from GFLAGS modules" OFF)
+IF(GFLAGS_STRIP_INTERNAL_FLAG_HELP)   
+  SET(STRIP_INTERNAL_FLAG_HELP 1)
+ELSE(GFLAGS_STRIP_INTERNAL_FLAG_HELP)
+  SET(STRIP_INTERNAL_FLAG_HELP 0)
+ENDIF(GFLAGS_STRIP_INTERNAL_FLAG_HELP)
+
 # maintain binary backwards compatibility with gflags library version <= 2.0,
 # but at the same time enable the use of the preferred new "gflags" namespace
 gflags_define (STRING NAMESPACE "Name(s) of library namespace (separate multiple options by semicolon)" "google;${PACKAGE_NAME}" "${PACKAGE_NAME}")

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -50,6 +50,8 @@
 #  define __STDC_FORMAT_MACROS 1
 #endif
 
+#cmakedefine STRIP_INTERNAL_FLAG_HELP
+
 // ---------------------------------------------------------------------------
 // Package information
 
@@ -109,6 +111,5 @@
 #  endif
 #  include "windows_port.h"
 #endif
-
 
 #endif // GFLAGS_CONFIG_H_

--- a/src/gflags.cc
+++ b/src/gflags.cc
@@ -87,10 +87,6 @@
 // other hand, hooks into CommandLineFlagParser.  Other API functions
 // are, similarly, mostly hooks into the functionality described above.
 
-#ifdef STRIP_INTERNAL_FLAG_HELP
-#  define STRIP_FLAG_HELP 1
-#endif
-
 #include "config.h"
 
 #ifdef STRIP_INTERNAL_FLAG_HELP

--- a/src/gflags.cc
+++ b/src/gflags.cc
@@ -87,7 +87,16 @@
 // other hand, hooks into CommandLineFlagParser.  Other API functions
 // are, similarly, mostly hooks into the functionality described above.
 
+#ifdef STRIP_INTERNAL_FLAG_HELP
+#  define STRIP_FLAG_HELP 1
+#endif
+
 #include "config.h"
+
+#ifdef STRIP_INTERNAL_FLAG_HELP
+#  define STRIP_FLAG_HELP 1
+#endif
+
 #include "gflags/gflags.h"
 
 #include <assert.h>

--- a/src/gflags_completions.cc
+++ b/src/gflags_completions.cc
@@ -56,6 +56,11 @@
 #include <vector>
 
 #include "config.h"
+
+#ifdef STRIP_INTERNAL_FLAG_HELP
+#  define STRIP_FLAG_HELP 1
+#endif
+
 #include "gflags/gflags.h"
 #include "gflags/gflags_completions.h"
 #include "util.h"

--- a/src/gflags_reporting.cc
+++ b/src/gflags_reporting.cc
@@ -56,6 +56,11 @@
 #include <vector>
 
 #include "config.h"
+
+#ifdef STRIP_INTERNAL_FLAG_HELP
+#  define STRIP_FLAG_HELP 1
+#endif
+
 #include "gflags/gflags.h"
 #include "gflags/gflags_completions.h"
 #include "util.h"
@@ -284,7 +289,11 @@ static void ShowUsageWithFlagsMatching(const char *argv0,
             fprintf(stdout, "\n\n");   // put blank lines between directories
           first_directory = false;
         }
+#ifdef STRIP_INTERNAL_FLAG_HELP
+        fprintf(stdout, "\n\n");
+#else
         fprintf(stdout, "\n  Flags from %s:\n", flag->filename.c_str());
+#endif  // STRIP_INTERNAL_FLAG_HELP
         last_filename = flag->filename;
       }
       // Now print this flag


### PR DESCRIPTION
Hi, working on my app (CLI) and using default configuration you get the text below when you ask for help (--help). I added a config option so you can strip all extra text from GFLAGS when you ask for help.

When building GFLAGS setting the cmake option GFLAGS_STRIP_INTERNAL_FLAG_HELP (BOOL) to 0 (which is the default value so you could avoid it) you get the following when building and running your app:

```
C:\>myapp-cli.exe --help
myapp-cli.exe: myapp-cli.exe --my_app_param=<VALUE>

  Flags from C:\some\path\to\gflags\src\gflags.cc:
    -flagfile (load flags from file) type: string default: ""
    -fromenv (set flags from the environment [use 'export FLAGS_flag1=value'])
      type: string default: ""
    -tryfromenv (set flags from the environment if present) type: string
      default: ""
    -undefok (comma-separated list of flag names that it is okay to specify on
      the command line even if the program does not define a flag with that
      name.  IMPORTANT: flags in this list that have arguments MUST use the
      flag=value format) type: string default: ""

  Flags from C:\some\path\to\gflags\src\gflags_completions.cc:
    -tab_completion_columns (Number of columns to use in output for tab
      completion) type: int32 default: 80
    -tab_completion_word (If non-empty, HandleCommandLineCompletions() will
      hijack the process and attempt to do bash-style command line flag
      completion on this value.) type: string default: ""

  Flags from C:\some\path\to\gflags\src\gflags_reporting.cc:
    -help (show help on all flags [tip: all flags can have two dashes])
      type: bool default: false currently: true
    -helpfull (show help on all flags -- same as -help) type: bool
      default: false
    -helpmatch (show help on modules whose name contains the specified substr)
      type: string default: ""
    -helpon (show help on the modules named by this flag value) type: string
      default: ""
    -helppackage (show help on all modules in the main package) type: bool
      default: false
    -helpshort (show help on only the main module for this program) type: bool
      default: false
    -helpxml (produce an xml version of help) type: bool default: false
    -version (show version and build info and exit) type: bool default: false


  Flags from C:\some\path\to\my\app\src\main.cpp:
    -my_app_param (Nice description) type: string
      default: ""
    -my_app_awesome_param (Really nice description) type: string
      default: ""

C:\>
```

When building GFLAGS setting the cmake option GFLAGS_STRIP_INTERNAL_FLAG_HELP (BOOL) to 1  you get the following when building and running your app:

```
C:\>myapp-cli.exe --help
myapp-cli.exe: myapp-cli.exe --my_app_param=<VALUE>

    -my_app_param (Nice description) type: string
      default: ""
    -my_app_awesome_param (Really nice description) type: string
      default: ""

C:\>
```

It works for me. Hope this could be helpful for others too :)

Thanks,

Best regards,
Daniel.