### PR TITLE
Use inttypes.h on VC++ 2013 and up

### DIFF
--- a/src/windows_port.h
+++ b/src/windows_port.h
@@ -109,10 +109,14 @@ inline void setenv(const char* name, const char* value, int) {
 #define unlink   _unlink
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER >= 1800
+#include <inttypes.h>
+#else
 #define PRId32  "d"
 #define PRIu32  "u"
 #define PRId64  "I64d"
 #define PRIu64  "I64u"
+#endif
 
 #if !defined(__MINGW32__) && !defined(__MINGW64__)
 #define strtoq   _strtoi64


### PR DESCRIPTION
Warnings will spit out on newer compilers due to PRI* being redefined.
Tested with VC++ 2015 and 2017. [Blog post](https://blogs.msdn.microsoft.com/vcblog/2013/07/19/c99-library-support-in-visual-studio-2013/) describing the defines being added in 2013.