### PR TITLE
Bazel does not complain config.h cannot be found.

### DIFF
--- a/bazel/gflags.bzl
+++ b/bazel/gflags.bzl
@@ -62,6 +62,7 @@ def gflags_sources(namespace=["google", "gflags"]):
 def gflags_library(hdrs=[], srcs=[], threads=1):
     name = "gflags"
     copts = [
+        "-I$(GENDIR)/" + PACKAGE_NAME,
         "-DHAVE_STDINT_H",
         "-DHAVE_SYS_TYPES_H",
         "-DHAVE_INTTYPES_H",


### PR DESCRIPTION
This PR fixes the same issue that the PR below already fixed:
https://github.com/gflags/gflags/pull/150