### PR TITLE
git: Ignore symbolic links created by Bazel build tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ CMakeFiles/
 /test/gflags_unittest-main.cc
 /packages/
 CMakeLists.txt.user
+/bazel-bin
+/bazel-genfiles
+/bazel-gflags
+/bazel-out
+/bazel-testlogs


### PR DESCRIPTION
Add some entries to `.gitignore` relating to symbolic links to products created by Bazel.