### PR TITLE
fix: Remove obsolete and unused CleanFileName code

### DIFF
--- a/src/gflags.cc
+++ b/src/gflags.cc
@@ -580,26 +580,14 @@ CommandLineFlag::~CommandLineFlag() {
 }
 
 const char* CommandLineFlag::CleanFileName() const {
-  // Compute top-level directory & file that this appears in
-  // search full path backwards.
-  // Stop going backwards at kRootDir; and skip by the first slash.
-  static const char kRootDir[] = "";    // can set this to root directory,
-
-  if (sizeof(kRootDir)-1 == 0)          // no prefix to strip
-    return filename();
-
-  const char* clean_name = filename() + strlen(filename()) - 1;
-  while ( clean_name > filename() ) {
-    if (*clean_name == PATH_SEPARATOR) {
-      if (sizeof(kRootDir) > 1 && strncmp(clean_name, kRootDir, sizeof(kRootDir)-1) == 0) {
-        clean_name += sizeof(kRootDir)-1;    // past root-dir
-        break;
-      }
-    }
-    --clean_name;
-  }
-  while ( *clean_name == PATH_SEPARATOR ) ++clean_name;  // Skip any slashes
-  return clean_name;
+  // This function has been used to strip off a common prefix from
+  // flag source file names. Because flags can be defined in different
+  // shared libraries, there may not be a single common prefix.
+  // Further, this functionality hasn't been active for many years.
+  // Need a better way to produce more user friendly help output or
+  // "anonymize" file paths in help output, respectively.
+  // Follow issue at: https://github.com/gflags/gflags/issues/86
+  return filename();
 }
 
 void CommandLineFlag::FillCommandLineFlagInfo(


### PR DESCRIPTION
Get rid of unused `kRootDir` once and for all. If such file name cleaning is desired, we need to come up with a better/more sustainable solution. Keeping this meaningless code around just causes confusion.

See also #86.