### PR TITLE
Bazel fixes for Windows builds

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -6,6 +6,12 @@ licenses(["notice"])
 
 exports_files(["src/gflags_completions.sh", "COPYING.txt"])
 
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+    visibility = [":__subpackages__"],
+)
+
 load(":bazel/gflags.bzl", "gflags_sources", "gflags_library")
 (hdrs, srcs) = gflags_sources(namespace=["gflags", "google"])
 gflags_library(hdrs=hdrs, srcs=srcs, threads=0)

--- a/bazel/gflags.bzl
+++ b/bazel/gflags.bzl
@@ -65,10 +65,8 @@ def gflags_library(hdrs=[], srcs=[], threads=1):
         "-DHAVE_INTTYPES_H",
         "-DHAVE_SYS_STAT_H",
         "-DHAVE_UNISTD_H",
-        "-DHAVE_FNMATCH_H",
         "-DHAVE_STRTOLL",
         "-DHAVE_STRTOQ",
-        "-DHAVE_PTHREAD",
         "-DHAVE_RWLOCK",
     ]
     linkopts = []
@@ -80,8 +78,21 @@ def gflags_library(hdrs=[], srcs=[], threads=1):
     native.cc_library(
         name       = name,
         hdrs       = hdrs,
-        srcs       = srcs,
-        copts      = copts,
+        srcs       = srcs + select({
+            "//:windows": [
+                "src/windows_port.h",
+            ],
+            "//conditions:default": [],
+        }),
+        copts      = copts + select({
+            "//:windows": [
+                "-DOS_WINDOWS",
+            ],
+            "//conditions:default": [
+                "-DHAVE_FNMATCH_H",
+                "-DHAVE_PTHREAD",
+            ],
+        }),
         linkopts   = linkopts,
         visibility = ["//visibility:public"],
         include_prefix = 'gflags'


### PR DESCRIPTION
Various fixes for building on Windows with bazel (#242 )

* fnmatch.h doesn't exist
* pthread.h doesn't exist
* windows.h wasn't being included via config.h because OS_WINDOWS wasn't defined. 