### PR TITLE
few CMake Update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,10 +70,14 @@
 ## - GFLAGS_INSTALL_SHARED_LIBS
 ## - GFLAGS_INSTALL_STATIC_LIBS
 
-cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.0.2 FATAL_ERROR)
 
 if (POLICY CMP0042)
   cmake_policy (SET CMP0042 NEW)
+endif ()
+
+if (POLICY CMP0048)
+  cmake_policy (SET CMP0048 NEW)
 endif ()
 
 # ----------------------------------------------------------------------------
@@ -90,7 +94,7 @@ set (PACKAGE_BUGREPORT   "https://github.com/gflags/gflags/issues")
 set (PACKAGE_DESCRIPTION "A commandline flags library that allows for distributed flags.")
 set (PACKAGE_URL         "http://gflags.github.io/gflags")
 
-project (${PACKAGE_NAME} CXX)
+project (${PACKAGE_NAME} VERSION ${PACKAGE_VERSION} LANGUAGES CXX)
 if (CMAKE_VERSION VERSION_LESS 3.4)
   # C language still needed because the following required CMake modules
   # (or their dependencies, respectively) are not correctly handling

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@
 ##
 ## When this project is a subproject (GFLAGS_IS_SUBPROJECT is TRUE), the default
 ## settings are such that only the static single-threaded library is built without
-## installation of the gflags files. The "gflags" target is in this case an ALIAS
+## installation of the gflags files. The "gflags::gflags" target is in this case an ALIAS
 ## library target for the "gflags_nothreads_static" library target. Targets which
-## depend on the gflags library should link to the "gflags" library target.
+## depend on the gflags library should link to the "gflags::gflags" library target.
 ##
 ## Example CMakeLists.txt of user project which requires separate gflags installation:
 ##   cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
@@ -26,7 +26,7 @@
 ##   find_package(gflags REQUIRED)
 ##
 ##   add_executable(foo src/foo.cc)
-##   target_link_libraries(foo gflags)
+##   target_link_libraries(foo gflags::gflags)
 ##
 ## Example CMakeLists.txt of user project which requires separate single-threaded static gflags installation:
 ##   cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
@@ -36,7 +36,7 @@
 ##   find_package(gflags COMPONENTS nothreads_static)
 ##
 ##   add_executable(foo src/foo.cc)
-##   target_link_libraries(foo gflags)
+##   target_link_libraries(foo gflags::gflags)
 ##
 ## Example CMakeLists.txt of super-project which contains gflags source tree:
 ##   cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
@@ -46,7 +46,7 @@
 ##   add_subdirectory(gflags)
 ##
 ##   add_executable(foo src/foo.cc)
-##   target_link_libraries(foo gflags)
+##   target_link_libraries(foo gflags::gflags)
 ##
 ## Variables to configure the source files:
 ## - GFLAGS_IS_A_DLL
@@ -495,11 +495,11 @@ if (GFLAGS_IS_SUBPROJECT)
   foreach (type IN ITEMS static shared)
     foreach (opts IN ITEMS "_nothreads" "")
       if (TARGET gflags${opts}_${type})
-        add_library (gflags ALIAS gflags${opts}_${type})
+        add_library (gflags::gflags ALIAS gflags${opts}_${type})
         break ()
       endif ()
     endforeach ()
-    if (TARGET gflags)
+    if (TARGET gflags::gflags)
        break ()
     endif ()
   endforeach ()
@@ -546,7 +546,11 @@ if (INSTALL_HEADERS)
     FILES "${PROJECT_BINARY_DIR}/${PACKAGE_NAME}-config-version.cmake"
     DESTINATION ${CONFIG_INSTALL_DIR}
   )
-  install (EXPORT ${EXPORT_NAME} DESTINATION ${CONFIG_INSTALL_DIR})
+  install (
+    EXPORT ${EXPORT_NAME}
+    DESTINATION ${CONFIG_INSTALL_DIR}
+    NAMESPACE gflags::
+  )
   if (UNIX)
     install (PROGRAMS src/gflags_completions.sh DESTINATION ${RUNTIME_INSTALL_DIR})
   endif ()
@@ -560,7 +564,10 @@ endif ()
 # ----------------------------------------------------------------------------
 # support direct use of build tree
 set (INSTALL_PREFIX_REL2CONFIG_DIR .)
-export (TARGETS ${TARGETS} FILE "${PROJECT_BINARY_DIR}/${EXPORT_NAME}.cmake")
+export (
+  TARGETS ${TARGETS}
+  NAMESPACE gflags::
+  FILE "${PROJECT_BINARY_DIR}/${EXPORT_NAME}.cmake")
 if (REGISTER_BUILD_DIR)
   export (PACKAGE ${PACKAGE_NAME})
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,7 +573,6 @@ configure_file (cmake/config.cmake.in "${PROJECT_BINARY_DIR}/${PACKAGE_NAME}-con
 # testing - MUST follow the generation of the build tree config file
 if (BUILD_TESTING)
   include (CTest)
-  enable_testing ()
   add_subdirectory (test)
 endif ()
 

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -49,7 +49,7 @@ if (NOT DEFINED @PACKAGE_PREFIX@_SHARED)
     else ()
       set (@PACKAGE_PREFIX@_SHARED FALSE)
     endif ()
-  elseif (TARGET @PACKAGE_NAME@_shared OR TARGET @PACKAGE_NAME@_nothreads_shared)
+  elseif (TARGET gflags::@PACKAGE_NAME@_shared OR TARGET gflags::@PACKAGE_NAME@_nothreads_shared)
     set (@PACKAGE_PREFIX@_SHARED TRUE)
   else ()
     set (@PACKAGE_PREFIX@_SHARED FALSE)
@@ -64,7 +64,7 @@ if (NOT DEFINED @PACKAGE_PREFIX@_NOTHREADS)
     else ()
       set (@PACKAGE_PREFIX@_NOTHREADS FALSE)
     endif ()
-  elseif (TARGET @PACKAGE_NAME@_static OR TARGET @PACKAGE_NAME@_shared)
+  elseif (TARGET gflags::@PACKAGE_NAME@_static OR TARGET gflags::@PACKAGE_NAME@_shared)
     set (@PACKAGE_PREFIX@_NOTHREADS FALSE)
   else ()
     set (@PACKAGE_PREFIX@_NOTHREADS TRUE)
@@ -77,15 +77,15 @@ if (NOT @PACKAGE_PREFIX@_TARGET)
     set (@PACKAGE_PREFIX@_TARGET ${@PACKAGE_NAME@_TARGET})
   elseif (@PACKAGE_PREFIX@_SHARED)
     if (@PACKAGE_PREFIX@_NOTHREADS)
-      set (@PACKAGE_PREFIX@_TARGET @PACKAGE_NAME@_nothreads_shared)
+      set (@PACKAGE_PREFIX@_TARGET gflags::@PACKAGE_NAME@_nothreads_shared)
     else ()
-      set (@PACKAGE_PREFIX@_TARGET @PACKAGE_NAME@_shared)
+      set (@PACKAGE_PREFIX@_TARGET gflags::@PACKAGE_NAME@_shared)
     endif ()
   else ()
     if (@PACKAGE_PREFIX@_NOTHREADS)
-      set (@PACKAGE_PREFIX@_TARGET @PACKAGE_NAME@_nothreads_static)
+      set (@PACKAGE_PREFIX@_TARGET gflags::@PACKAGE_NAME@_nothreads_static)
     else ()
-      set (@PACKAGE_PREFIX@_TARGET @PACKAGE_NAME@_static)
+      set (@PACKAGE_PREFIX@_TARGET gflags::@PACKAGE_NAME@_static)
     endif ()
   endif ()
 endif ()
@@ -94,12 +94,12 @@ if (NOT TARGET ${@PACKAGE_PREFIX@_TARGET})
                        " Try a different combination of @PACKAGE_PREFIX@_SHARED and @PACKAGE_PREFIX@_NOTHREADS.")
 endif ()
 
-# add more convenient "@PACKAGE_NAME@" import target
-if (NOT TARGET @PACKAGE_NAME@)
+# add more convenient "gflags::@PACKAGE_NAME@" import target
+if (NOT TARGET gflags::@PACKAGE_NAME@)
   if (@PACKAGE_PREFIX@_SHARED)
-    add_library (@PACKAGE_NAME@ SHARED IMPORTED)
+    add_library (gflags::@PACKAGE_NAME@ SHARED IMPORTED)
   else ()
-    add_library (@PACKAGE_NAME@ STATIC IMPORTED)
+    add_library (gflags::@PACKAGE_NAME@ STATIC IMPORTED)
   endif ()
   # copy INTERFACE_* properties
   foreach (_@PACKAGE_PREFIX@_PROPERTY_NAME IN ITEMS
@@ -112,20 +112,20 @@ if (NOT TARGET @PACKAGE_NAME@)
   )
     get_target_property (_@PACKAGE_PREFIX@_PROPERTY_VALUE ${@PACKAGE_PREFIX@_TARGET} INTERFACE_${_@PACKAGE_PREFIX@_PROPERTY_NAME})
     if (_@PACKAGE_PREFIX@_PROPERTY_VALUE)
-      set_target_properties(@PACKAGE_NAME@ PROPERTIES
+      set_target_properties(gflags::@PACKAGE_NAME@ PROPERTIES
         INTERFACE_${_@PACKAGE_PREFIX@_PROPERTY_NAME} "${_@PACKAGE_PREFIX@_PROPERTY_VALUE}"
       )
     endif ()
   endforeach ()
   # copy IMPORTED_*_<CONFIG> properties
   get_target_property (_@PACKAGE_PREFIX@_CONFIGURATIONS ${@PACKAGE_PREFIX@_TARGET} IMPORTED_CONFIGURATIONS)
-  set_target_properties (@PACKAGE_NAME@ PROPERTIES IMPORTED_CONFIGURATIONS "${_@PACKAGE_PREFIX@_CONFIGURATIONS}")
+  set_target_properties (gflags::@PACKAGE_NAME@ PROPERTIES IMPORTED_CONFIGURATIONS "${_@PACKAGE_PREFIX@_CONFIGURATIONS}")
   foreach (_@PACKAGE_PREFIX@_PROPERTY_NAME IN ITEMS
     IMPLIB
     LOCATION
     LINK_DEPENDENT_LIBRARIES
     LINK_INTERFACE_LIBRARIES
-    LINK_INTERFACE_LANGUAGES 
+    LINK_INTERFACE_LANGUAGES
     LINK_INTERFACE_MULTIPLICITY
     NO_SONAME
     SONAME
@@ -133,7 +133,7 @@ if (NOT TARGET @PACKAGE_NAME@)
     foreach (_@PACKAGE_PREFIX@_CONFIG IN LISTS _@PACKAGE_PREFIX@_CONFIGURATIONS)
       get_target_property (_@PACKAGE_PREFIX@_PROPERTY_VALUE ${@PACKAGE_PREFIX@_TARGET} IMPORTED_${_@PACKAGE_PREFIX@_PROPERTY_NAME}_${_@PACKAGE_PREFIX@_CONFIG})
       if (_@PACKAGE_PREFIX@_PROPERTY_VALUE)
-        set_target_properties(@PACKAGE_NAME@ PROPERTIES
+        set_target_properties(gflags::@PACKAGE_NAME@ PROPERTIES
           IMPORTED_${_@PACKAGE_PREFIX@_PROPERTY_NAME}_${_@PACKAGE_PREFIX@_CONFIG} "${_@PACKAGE_PREFIX@_PROPERTY_VALUE}"
         )
       endif ()

--- a/test/config/CMakeLists.txt
+++ b/test/config/CMakeLists.txt
@@ -7,4 +7,4 @@ project (gflags_${TEST_NAME})
 find_package (gflags REQUIRED)
 
 add_executable (foo main.cc)
-target_link_libraries (foo gflags)
+target_link_libraries (foo gflags::gflags)


### PR DESCRIPTION
- add VERSION to project command
- remove uneeded `enable_testing()` command
- Move gflags target(s) to gflags:: namespace

note: [gRPC CMakeLists.txt](https://github.com/grpc/grpc/blob/master/cmake/gflags.cmake#L30) seems already to look for target gflags::gflags ...