### PR TITLE
Set postfixes for generated libraries based on buildtype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,6 +403,9 @@ if (NOT GFLAGS_IS_SUBPROJECT)
   set (CMAKE_LIBRARY_OUTPUT_DIRECTORY "lib")
   set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY "lib")
 endif ()
+# Set postfixes for generated libraries based on buildtype.
+set(CMAKE_RELEASE_POSTFIX "")
+set(CMAKE_DEBUG_POSTFIX "_debug")
 
 # ----------------------------------------------------------------------------
 # installation directories


### PR DESCRIPTION
In order to distinguish the libraries based on 'debug' and 'release', add extra postfix '_debug' for debug mode.