### PR TITLE
fix: Use 'default' visibility for GCC

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -36,6 +36,8 @@
 #ifndef GFLAGS_DLL_DECL
 #  if GFLAGS_IS_A_DLL && defined(_MSC_VER)
 #    define GFLAGS_DLL_DECL __declspec(dllexport)
+#  elif defined(__GNUC__) && __GNUC__ >= 4
+#    define GFLAGS_DLL_DECL __attribute__((visibility("default")))
 #  else
 #    define GFLAGS_DLL_DECL
 #  endif

--- a/src/gflags_declare.h.in
+++ b/src/gflags_declare.h.in
@@ -58,6 +58,8 @@
 #ifndef GFLAGS_DLL_DECL
 #  if GFLAGS_IS_A_DLL && defined(_MSC_VER)
 #    define GFLAGS_DLL_DECL __declspec(dllimport)
+#  elif defined(__GNUC__) && __GNUC__ >= 4
+#    define GFLAGS_DLL_DECL __attribute__((visibility("default")))
 #  else
 #    define GFLAGS_DLL_DECL
 #  endif
@@ -67,6 +69,8 @@
 #ifndef GFLAGS_DLL_DECLARE_FLAG
 #  if GFLAGS_IS_A_DLL && defined(_MSC_VER)
 #    define GFLAGS_DLL_DECLARE_FLAG __declspec(dllimport)
+#  elif defined(__GNUC__) && __GNUC__ >= 4
+#    define GFLAGS_DLL_DECLARE_FLAG __attribute__((visibility("default")))
 #  else
 #    define GFLAGS_DLL_DECLARE_FLAG
 #  endif


### PR DESCRIPTION
Fixes #267.

Tested with https://github.com/gflags/example project in Ubuntu WSL using GCC 7.3 (Ubuntu 7.3.0-27ubuntu1~18.04).