### PR TITLE
package.pc.in: bin and libdir to exec_prefix

### DIFF
--- a/cmake/package.pc.in
+++ b/cmake/package.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-bindir=${prefix}/@RUNTIME_INSTALL_DIR@
-libdir=${prefix}/@LIBRARY_INSTALL_DIR@
+bindir=${exec_prefix}/@RUNTIME_INSTALL_DIR@
+libdir=${exec_prefix}/@LIBRARY_INSTALL_DIR@
 includedir=${prefix}/@INCLUDE_INSTALL_DIR@
 
 Name: @PACKAGE_NAME@


### PR DESCRIPTION
More consistent with other pkgconfig files.

No functional difference.