### PR TITLE
Avoid no-match message in case STRIP_FLAG_HELP been set

### DIFF
--- a/src/gflags_reporting.cc
+++ b/src/gflags_reporting.cc
@@ -275,9 +275,9 @@ static void ShowUsageWithFlagsMatching(const char *argv0,
        ++flag) {
     if (substrings.empty() ||
         FileMatchesSubstring(flag->filename, substrings)) {
+      found_match = true;     // this flag passed the match!
       // If the flag has been stripped, pretend that it doesn't exist.
       if (flag->description == kStrippedFlagHelp) continue;
-      found_match = true;     // this flag passed the match!
       if (flag->filename != last_filename) {                      // new file
         if (Dirname(flag->filename) != Dirname(last_filename)) {  // new dir!
           if (!first_directory)


### PR DESCRIPTION
If the workaround in issue #43 is used along with the define of
STRIP_FLAG_HELP to 1, there would be a wrong "No modules matched"
message been print at end of the usage message.

That's because we continue the loop if we see strip flag help value and
never set the `found_match` flag to true even if we found a match.

By moving the set statement above the continue, we can avoid this wrong
message.