### PR TITLE
remove visibility attribute where it does not apply

### DIFF
--- a/src/gflags.h.in
+++ b/src/gflags.h.in
@@ -223,7 +223,7 @@ extern GFLAGS_DLL_DECL bool GetCommandLineFlagInfo(const char* name, CommandLine
 //   if (GetCommandLineFlagInfoOrDie("foo").is_default) ...
 extern GFLAGS_DLL_DECL CommandLineFlagInfo GetCommandLineFlagInfoOrDie(const char* name);
 
-enum GFLAGS_DLL_DECL FlagSettingMode {
+enum FlagSettingMode {
   // update the flag's value (can call this multiple times).
   SET_FLAGS_VALUE,
   // update the flag's value, but *only if* it has not yet been updated


### PR DESCRIPTION
```
gflags.h(226): warning: attribute "visibility" does not apply here
```

The visibility attribute applies to symbols like functions and variables. A definition of an enumeration type that doesn't contain a variable name doesn't create any symbols.