### PR TITLE
Remove fallthrough switch case

### DIFF
--- a/src/gflags_completions.cc
+++ b/src/gflags_completions.cc
@@ -326,20 +326,9 @@ static void CanonicalizeCursorWordAndSearchOptions(
     break;
   }
   
-  if (found_question_marks == 3) {
-    options->flag_description_substring_search = true;
-    options->flag_location_substring_search = true;
-    options->flag_name_substring_search = true;
-  }
-  
-  if (found_question_marks == 2) {
-    options->flag_location_substring_search = true;
-    options->flag_name_substring_search = true;
-  }
-  
-  if (found_question_marks == 1) {
-    options->flag_name_substring_search = true;
-  }
+  if (found_question_marks > 2) options->flag_description_substring_search = true;
+  if (found_question_marks > 1) options->flag_location_substring_search = true;
+  if (found_question_marks > 0) options->flag_name_substring_search = true;
 
   options->return_all_matching_flags = (found_plusses > 0);
 }

--- a/src/gflags_completions.cc
+++ b/src/gflags_completions.cc
@@ -325,12 +325,21 @@ static void CanonicalizeCursorWordAndSearchOptions(
     }
     break;
   }
-
-  switch (found_question_marks) {  // all fallthroughs
-    case 3: options->flag_description_substring_search = true;
-    case 2: options->flag_location_substring_search = true;
-    case 1: options->flag_name_substring_search = true;
-  };
+  
+  if (found_question_marks == 3) {
+    options->flag_description_substring_search = true;
+    options->flag_location_substring_search = true;
+    options->flag_name_substring_search = true;
+  }
+  
+  if (found_question_marks == 2) {
+    options->flag_location_substring_search = true;
+    options->flag_name_substring_search = true;
+  }
+  
+  if (found_question_marks == 1) {
+    options->flag_name_substring_search = true;
+  }
 
   options->return_all_matching_flags = (found_plusses > 0);
 }


### PR DESCRIPTION
GCC gives an implicit-fallthrough warning (included in -Wextra). C++17 has the `[[fallthrough]]` attribute, and GCC7+ has `__attribute__((fallthrough))`, but I didn't want to require either so I refactored the switch into if statements.