### PR TITLE
Remove msys dependency for Windows.

### DIFF
--- a/bazel/expanded_template/BUILD
+++ b/bazel/expanded_template/BUILD
@@ -1,0 +1,5 @@
+cc_binary(
+    name = "expand_template",
+    srcs = ["expand_template.cc"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/expanded_template/expand_template.cc
+++ b/bazel/expanded_template/expand_template.cc
@@ -1,0 +1,62 @@
+#include <fstream>
+#include <regex>
+#include <streambuf>
+#include <string>
+#include <vector>
+
+struct Substitution {
+  std::basic_regex<char> regex;
+  std::string replacement;
+};
+
+// Simple app that does a regex search-and-replace on a template
+// and outputs the result.
+//
+// To invoke:
+// expand_template
+// --template PATH
+// --output PATH
+// regex0;replacement0
+// regex1;replacement1
+// ...
+//
+// Since it's only used as a private implementation detail of a rule and not
+// user invoked we don't bother with error checking.
+int main(int argc, const char** argv) {
+  // Parse args.
+  const char* template_path = nullptr;
+  const char* output_path = nullptr;
+  std::vector<Substitution> substitutions;
+  for (int i = 1; i < argc; ++i) {
+    const char* arg = argv[i];
+    if (strcmp(arg, "--template") == 0) {
+      template_path = argv[++i];
+    } else if (strcmp(arg, "--output") == 0) {
+      output_path = argv[++i];
+    } else {
+      const char* mid = strchr(arg, ';');
+      if (mid != nullptr) {
+        substitutions.push_back(Substitution{
+            std::basic_regex<char>(arg, mid - arg),
+            std::string(mid + 1),
+        });
+      }
+    }
+  }
+
+  // Read template.
+  std::ifstream ifs(template_path);
+  std::string str(std::istreambuf_iterator<char>(ifs),
+                  (std::istreambuf_iterator<char>()));
+
+  // Apply regexes.
+  for (const auto& subst : substitutions) {
+    str = std::regex_replace(str, subst.regex, subst.replacement);
+  }
+
+  // Output file.
+  std::ofstream file(output_path);
+  file << str;
+
+  return 0;
+}

--- a/bazel/expanded_template/expanded_template.bzl
+++ b/bazel/expanded_template/expanded_template.bzl
@@ -1,0 +1,35 @@
+def _impl(ctx):
+    args = ctx.actions.args()
+    args.add("--template", ctx.file.template)
+    args.add("--output", ctx.outputs.out)
+    args.add_all([k + ';' + v for k, v in ctx.attr.substitutions.items()])
+    ctx.actions.run(
+        executable = ctx.executable._bin,
+        arguments = [args],
+        inputs = [ctx.file.template],
+        outputs = [ctx.outputs.out],
+    )
+    return [
+        DefaultInfo(
+            files = depset(direct = [ctx.outputs.out]),
+            runfiles = ctx.runfiles(files = [ctx.outputs.out]),
+        ),
+    ]
+
+expanded_template = rule(
+    implementation = _impl,
+    attrs = {
+        "out": attr.output(mandatory = True),
+        "template": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "substitutions": attr.string_dict(),
+        "_bin": attr.label(
+            default = "//bazel/expanded_template:expand_template",
+            executable = True,
+            allow_single_file = True,
+            cfg = "host",
+        ),
+    },
+)


### PR DESCRIPTION
Bazel genrules require a msys shell to execute
shell commands. Replace the genrules with a
simple C++ regex replacement binary.

Fixes #303.