### PR TITLE
Include string.h for strchr and strcmp.

### DIFF
--- a/bazel/expanded_template/expand_template.cc
+++ b/bazel/expanded_template/expand_template.cc
@@ -2,6 +2,7 @@
 #include <regex>
 #include <streambuf>
 #include <string>
+#include <string.h>
 #include <vector>
 
 struct Substitution {


### PR DESCRIPTION
This fixes a continuous build
(https://travis-ci.org/github/google/perf_data_converter/jobs/714589290)
running on Ubuntu 16.04 using gcc-4.8.

TESTED=Fresh install and system configuration following https://github.com/google/perf_data_converter/blob/master/.travis.yml