### PR TITLE
switch shebang to python3

### DIFF
--- a/test/gflags_build.py.in
+++ b/test/gflags_build.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
python2 is EOL, swith shebang to python3

Signed-off-by: Changqing Li <changqing.li@windriver.com>