### PR TITLE
Update docs. Add id to --flagfile so it can be jumped to

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -542,7 +542,7 @@ the application.</p>
 <p>Note it is still an error to say <code>--tryfromenv=foo</code> if
 <code>foo</code> is not DEFINED somewhere in the application.</p>
 
-<h3> <code>--flagfile</code> </h3>
+<h3 id="flagfiles"> <code>--flagfile</code> </h3>
 
 <p><code>--flagfile=f</code> tells the commandlineflags module to read
 the file <code>f</code>, and to run all the flag-assignments found in


### PR DESCRIPTION
This PR adds an `id` attribute to the `--flagfiles` flag header so that a link in the earlier part of the document works. i.e.

This link
<img width="1537" alt="image" src="https://user-images.githubusercontent.com/5422469/153253942-4bad884b-6e6a-4c3a-b751-5dfeef924f64.png">

Now links to this section
<img width="1521" alt="image" src="https://user-images.githubusercontent.com/5422469/153254080-c8f02c36-bf6e-42c1-aae7-4993f1940ee3.png">

Previously it did not link anywhere.