### PR TITLE
Fix: AllowCommandLineReparsing unuse

### DIFF
--- a/src/gflags.cc
+++ b/src/gflags.cc
@@ -1983,7 +1983,6 @@ uint32 ParseCommandLineNonHelpFlags(int* argc, char*** argv,
 //    dlopen, to get the new flags.  But you have to explicitly
 //    Allow() it; otherwise, you get the normal default behavior
 //    of unrecognized flags calling a fatal error.
-// TODO(csilvers): this isn't used.  Just delete it?
 // --------------------------------------------------------------------
 
 void AllowCommandLineReparsing() {
@@ -1991,6 +1990,10 @@ void AllowCommandLineReparsing() {
 }
 
 void ReparseCommandLineNonHelpFlags() {
+  // Check reparse status
+  if (!allow_command_line_reparsing) {
+    return;
+  }
   // We make a copy of argc and argv to pass in
   const vector<string>& argvs = GetArgvs();
   int tmp_argc = static_cast<int>(argvs.size());

--- a/src/gflags.cc
+++ b/src/gflags.cc
@@ -1991,9 +1991,7 @@ void AllowCommandLineReparsing() {
 
 void ReparseCommandLineNonHelpFlags() {
   // Check reparse status
-  if (!allow_command_line_reparsing) {
-    return;
-  }
+  assert(allow_command_line_reparsing);
   // We make a copy of argc and argv to pass in
   const vector<string>& argvs = GetArgvs();
   int tmp_argc = static_cast<int>(argvs.size());


### PR DESCRIPTION
As shown below,
```
// --------------------------------------------------------------------
// AllowCommandLineReparsing()
// ReparseCommandLineNonHelpFlags()
//    This is most useful for shared libraries.  The idea is if
//    a flag is defined in a shared library that is dlopen'ed
//    sometime after main(), you can ParseCommandLineFlags before
//    the dlopen, then ReparseCommandLineNonHelpFlags() after the
//    dlopen, to get the new flags.  But you have to explicitly
//    Allow() it; otherwise, you get the normal default behavior
//    of unrecognized flags calling a fatal error.
// --------------------------------------------------------------------
```

But `AllowCommandLineReparsing`  function dit not used by `ReparseCommandLineNonHelpFlags`. The commit fix code.  When invoke ReparseCommandLineNonHelpFlags,  code will check the allow status by `allow_command_line_reparsing`.
