### PR TITLE
QNX Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,14 +435,7 @@ else ()
   endif ()
   gflags_define (PATH LIBRARY_INSTALL_DIR "Directory of installed libraries, e.g., \"lib64\"" "lib${LIB_SUFFIX}")
   gflags_property (LIBRARY_INSTALL_DIR ADVANCED TRUE)
-  
-  # Cross-compiling for QNX does not install in the normal include path
-  if (QNX)
-    set (INCLUDE_INSTALL_DIR ${QNX_INCLUDE_INSTALL_DIR})
-  else()
-    set (INCLUDE_INSTALL_DIR include)
-  endif ()
-
+  set (INCLUDE_INSTALL_DIR include)
   set (CONFIG_INSTALL_DIR  ${LIBRARY_INSTALL_DIR}/cmake/${PACKAGE_NAME})
   set (PKGCONFIG_INSTALL_DIR ${LIBRARY_INSTALL_DIR}/pkgconfig)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,7 +435,14 @@ else ()
   endif ()
   gflags_define (PATH LIBRARY_INSTALL_DIR "Directory of installed libraries, e.g., \"lib64\"" "lib${LIB_SUFFIX}")
   gflags_property (LIBRARY_INSTALL_DIR ADVANCED TRUE)
-  set (INCLUDE_INSTALL_DIR include)
+  
+  # Cross-compiling for QNX does not install in the normal include path
+  if (QNX)
+    set (INCLUDE_INSTALL_DIR ${QNX_INCLUDE_INSTALL_DIR})
+  else()
+    set (INCLUDE_INSTALL_DIR include)
+  endif ()
+
   set (CONFIG_INSTALL_DIR  ${LIBRARY_INSTALL_DIR}/cmake/${PACKAGE_NAME})
   set (PKGCONFIG_INSTALL_DIR ${LIBRARY_INSTALL_DIR}/pkgconfig)
 endif ()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -169,20 +169,22 @@ add_test(NAME gflags_declare COMMAND gflags_declare_test --message "Hello gflags
 set_tests_properties(gflags_declare PROPERTIES PASS_REGULAR_EXPRESSION "Hello gflags!")
 
 # ----------------------------------------------------------------------------
-# QNX Specific Installation (ctest not compatible)
-if(QNX)
-install(DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-  DESTINATION ${RUNTIME_INSTALL_DIR}/gflags_tests)
-
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/test/
-  DESTINATION ${RUNTIME_INSTALL_DIR}/gflags_tests
-  FILES_MATCHING
-  PATTERN "flagfile.*"
-  PATTERN "gflags_unittest_flagfile"
-  PATTERN "config" EXCLUDE
-  PATTERN "nc" EXCLUDE
-)
-endif()
+# qnx specific test installation (ctest not compatible)
+if (QNX)
+  install (
+    DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    DESTINATION ${RUNTIME_INSTALL_DIR}/gflags_tests
+  )
+  install (
+    DIRECTORY ${PROJECT_SOURCE_DIR}/test/
+    DESTINATION ${RUNTIME_INSTALL_DIR}/gflags_tests
+    FILES_MATCHING
+    PATTERN "flagfile.*"
+    PATTERN "gflags_unittest_flagfile"
+    PATTERN "config" EXCLUDE
+    PATTERN "nc" EXCLUDE
+  )
+endif ()
 
 # ----------------------------------------------------------------------------
 # configure Python script which configures and builds a test project

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -169,6 +169,22 @@ add_test(NAME gflags_declare COMMAND gflags_declare_test --message "Hello gflags
 set_tests_properties(gflags_declare PROPERTIES PASS_REGULAR_EXPRESSION "Hello gflags!")
 
 # ----------------------------------------------------------------------------
+# QNX Specific Installation (ctest not compatible)
+if(QNX)
+install(DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+  DESTINATION ${RUNTIME_INSTALL_DIR}/gflags_tests)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/test/
+  DESTINATION ${RUNTIME_INSTALL_DIR}/gflags_tests
+  FILES_MATCHING
+  PATTERN "flagfile.*"
+  PATTERN "gflags_unittest_flagfile"
+  PATTERN "config" EXCLUDE
+  PATTERN "nc" EXCLUDE
+)
+endif()
+
+# ----------------------------------------------------------------------------
 # configure Python script which configures and builds a test project
 if (BUILD_NC_TESTS OR BUILD_CONFIG_TESTS)
   find_package (PythonInterp)


### PR DESCRIPTION
Hi!

I'm a part of the Open Source Software team at BlackBerry QNX and have been working to add QNX support to open-source libraries. we do maintain our own forks of some projects, but with smaller changes such as the ones required to cross-compile gflags we like to upstream them so that support is more accessible.

For more context- QNX is a RTOS mainly used in industry for automotive and robotics applications, but recently has been made free for non-commercial use. It is cross-compiled using a gcc toolchain, but due to being POSIX compliant works with most libraries with little modification.

The only changes I needed to make to get gflags to cross compile and pass tests on QNX was to modify the `INCLUDE_INSTALL_DIR` in CMakeLists.txt to point to a staging area, and compiling and installing tests as ctest does not typically play well with cross compilation for QNX.

All these changes are wrapped in if (QNX) statements and will not affect how gflags works when compiling for anything else!

Let me know if upstreaming these changes is something gflags would be interested in, and any changes I could/should make!

Best,
-JaiXJM