### PR TITLE
Update: Allow CMAKE_DEBUG_POSTFIX to be overridden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,7 +415,9 @@ if (NOT GFLAGS_IS_SUBPROJECT)
 endif ()
 # Set postfixes for generated libraries based on buildtype.
 set(CMAKE_RELEASE_POSTFIX "")
-set(CMAKE_DEBUG_POSTFIX "_debug")
+if(NOT DEFINED CMAKE_DEBUG_POSTFIX)
+  set(CMAKE_DEBUG_POSTFIX "_debug")
+endif()
 
 # ----------------------------------------------------------------------------
 # installation directories


### PR DESCRIPTION
Forcing _debug postfix will require applications to update their compile flags based on the release mode. 