### PR TITLE
ci: Point test.yml at main instead of master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Build and Run Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 concurrency:
   group: test-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- `test.yml`'s `push`/`pull_request` branch filters still say `master`. The default branch was renamed to `main` (see #391 discussion), so this workflow has not been triggering on pushes or PRs targeting `main` — including PR #390, which currently has zero CI checks.
- Updates both filters to `main`.

## Test plan
- [x] Confirm this workflow run itself (on this PR) actually triggers and passes, proving the fix works.