### PR TITLE
bazel: Fix `incompatible_disable_starlark_host_transitions`

### DIFF
--- a/bazel/expanded_template/expanded_template.bzl
+++ b/bazel/expanded_template/expanded_template.bzl
@@ -29,7 +29,7 @@ expanded_template = rule(
             default = "//bazel/expanded_template:expand_template",
             executable = True,
             allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
 )

--- a/bazel/expanded_template/expanded_template.bzl
+++ b/bazel/expanded_template/expanded_template.bzl
@@ -2,7 +2,7 @@ def _impl(ctx):
     args = ctx.actions.args()
     args.add("--template", ctx.file.template)
     args.add("--output", ctx.outputs.out)
-    args.add_all([k + ';' + v for k, v in ctx.attr.substitutions.items()])
+    args.add_all([k + ";" + v for k, v in ctx.attr.substitutions.items()])
     ctx.actions.run(
         executable = ctx.executable._bin,
         arguments = [args],


### PR DESCRIPTION
Fix `incompatible_disable_starlark_host_transitions` as per https://github.com/bazelbuild/bazel/issues/17032.

This popped up when [adding `gflags@2.3.1` to BCR](https://github.com/bazelbuild/bazel-central-registry/pull/9784), when CI tests for incompatible flags.

